### PR TITLE
Fixes crash on opening Treealyzer GUI #2

### DIFF
--- a/forestry_common/arboriculture/forestry/arboriculture/gui/ContainerTreealyzer.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gui/ContainerTreealyzer.java
@@ -33,10 +33,10 @@ public class ContainerTreealyzer extends ContainerItemInventory {
 		// Energy
 		this.addSlot(new SlotCustom(inventory, TreealyzerInventory.SLOT_ENERGY, 172, 8, new Object[] { ForestryItem.honeydew, ForestryItem.honeyDrop }));
 
-		// Bee to analyze
-		this.addSlot(new SlotCustom(inventory, TreealyzerInventory.SLOT_SPECIMEN, 172, 26,  ArrayUtils.addAll(AlleleManager.ersatzSaplings.keySet().toArray(new ItemStack[0]), ItemGermlingGE.class)));
+		// Tree to analyze
+		this.addSlot(new SlotCustom(inventory, TreealyzerInventory.SLOT_SPECIMEN, 172, 26,  ArrayUtils.addAll(AlleleManager.ersatzSaplings.keySet().toArray(new Object[0]), ItemGermlingGE.class)));
 
-		// Analyzed bee
+		// Analyzed tree
 		this.addSlot(new SlotCustom(inventory, TreealyzerInventory.SLOT_ANALYZE_1, 172, 57, new Object[] { ItemGermlingGE.class }));
 		this.addSlot(new SlotCustom(inventory, TreealyzerInventory.SLOT_ANALYZE_2, 172, 75, new Object[] { ItemGermlingGE.class }));
 		this.addSlot(new SlotCustom(inventory, TreealyzerInventory.SLOT_ANALYZE_3, 172, 93, new Object[] { ItemGermlingGE.class }));


### PR DESCRIPTION
As crash error was ItemStack cannot be cast to Object, then this seems to be the only solution.

Also updates some comments.
