### PR TITLE
Register flowers added to Minecraft 1.7.x

### DIFF
--- a/forestry_common/core/forestry/core/ForestryCore.java
+++ b/forestry_common/core/forestry/core/ForestryCore.java
@@ -126,7 +126,9 @@ public class ForestryCore {
 		FuelManager.rainSubstrate.put(ForestryItem.craftingMaterial.getItemStack(1, 4), new RainSubstrate(ForestryItem.craftingMaterial.getItemStack(1, 4), 0.075f));
 
 		// Set additional apiary flowers
-		FlowerManager.plainFlowers.add(new ItemStack(Blocks.red_flower));
+		for (int i=0; i<8; i++) {
+			FlowerManager.plainFlowers.add(new ItemStack(Blocks.red_flower, 1, i));
+		}
 		FlowerManager.plainFlowers.add(new ItemStack(Blocks.yellow_flower));
 
 		// Register gui handler


### PR DESCRIPTION
Register additional flowers added in 1.7, which use metadata in red_flower.

Of note, not registering DoublePlant flowers, due to problems with beehives generating these in world.
