### PR TITLE
Removed blocks with invalid items from backpack lists

### DIFF
--- a/forestry_common/storage/forestry/plugins/PluginStorage.java
+++ b/forestry_common/storage/forestry/plugins/PluginStorage.java
@@ -388,9 +388,7 @@ public class PluginStorage extends NativePlugin implements IOreDictionaryHandler
 		// [5] Set valid items in builder's backpack
 		builderItems.add(new ItemStack(Blocks.torch));
 		builderItems.add(new ItemStack(Blocks.redstone_torch));
-		builderItems.add(new ItemStack(Blocks.unlit_redstone_torch));
 		builderItems.add(new ItemStack(Blocks.redstone_lamp));
-		builderItems.add(new ItemStack(Blocks.lit_redstone_lamp));
 		builderItems.add(new ItemStack(ForestryBlock.candle));
 		builderItems.add(new ItemStack(ForestryBlock.stump));
 		builderItems.add(new ItemStack(Blocks.stonebrick, 1, Defaults.WILDCARD));

--- a/forestry_common/storage/forestry/storage/BackpackDefinition.java
+++ b/forestry_common/storage/forestry/storage/BackpackDefinition.java
@@ -61,7 +61,9 @@ public class BackpackDefinition implements IBackpackDefinition {
 
 	@Override
 	public void addValidItem(ItemStack validItem) {
-		this.validItems.add(validItem);
+		if (validItem.getItem() != null) {
+			this.validItems.add(validItem);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
There are several blocks that are either manually or automatically added to backpack lists that have invalid items.  These blocks are mostly technical blocks which normally cannot be obtained in game.  The 1.7.x item/block registries no longer convert these technical blocks into their item forms (the items may not even exist).  This causes the game to crash when you try to manually place certain items into some backpacks.  You can easily show the error by trying to place an invalid item in the forester's or builder's backpack (the other ones do not contain invalid items).

These blocks all have special item drops that prevent them from making valid ItemStacks.
In the Builder's backpack:
- redstone comparator (active)
- redstone torch (unlit)
- iron door (probably the top bit)
- wood door (probably the top bit)
- redstone repeater (active)
- redstone comparator (off)
- redstone repeater (off)
- redstone lamp (lit)

In the Forester's backpack:
- pumpkin stem
- nether wart
- crops (wheat)
- reeds
- melon stem
