### PR TITLE
Fix Naturalist Backpack dupe & delete bugs

### DIFF
--- a/forestry_common/storage/forestry/storage/PickupHandlerStorage.java
+++ b/forestry_common/storage/forestry/storage/PickupHandlerStorage.java
@@ -11,7 +11,7 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
-import forestry.core.gui.ContainerNaturalistInventory;
+import forestry.storage.gui.ContainerNaturalistBackpack;
 import forestry.core.interfaces.IPickupHandler;
 import forestry.storage.gui.ContainerBackpack;
 import forestry.storage.items.ItemBackpack;
@@ -27,7 +27,7 @@ public class PickupHandlerStorage implements IPickupHandler {
 
 		// Do not pick up if a backpack is open // FIXME: Must not contain
 		// anything from apiculture
-		if (player.openContainer instanceof ContainerBackpack || player.openContainer instanceof ContainerNaturalistInventory)
+		if (player.openContainer instanceof ContainerBackpack || player.openContainer instanceof ContainerNaturalistBackpack)
 			return true;
 
 		// Make sure to top off manually placed itemstacks in player


### PR DESCRIPTION
Fixes Issue #64 and Fixes Issue #65
Both issues still occurred on the latest master branch.

No backpack is a ContainerNaturalistInventory, so it makes sense that it was a typo for ContainerNaturalistBackpack. 

Now Naturalist Backpacks do not pick up items while open, just like every other backpack. This fixes the above two linked issues, one which duplicates items one that deletes them.
