### PR TITLE
fix license links

### DIFF
--- a/forestry_common/apiculture/forestry/apiculture/BeekeepingLogic.java
+++ b/forestry_common/apiculture/forestry/apiculture/BeekeepingLogic.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/CommandBeekeepingMode.java
+++ b/forestry_common/apiculture/forestry/apiculture/CommandBeekeepingMode.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/CommandGiveBee.java
+++ b/forestry_common/apiculture/forestry/apiculture/CommandGiveBee.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/FlowerProviderCacti.java
+++ b/forestry_common/apiculture/forestry/apiculture/FlowerProviderCacti.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/FlowerProviderEnd.java
+++ b/forestry_common/apiculture/forestry/apiculture/FlowerProviderEnd.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/FlowerProviderGourd.java
+++ b/forestry_common/apiculture/forestry/apiculture/FlowerProviderGourd.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/FlowerProviderJungle.java
+++ b/forestry_common/apiculture/forestry/apiculture/FlowerProviderJungle.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/FlowerProviderMushroom.java
+++ b/forestry_common/apiculture/forestry/apiculture/FlowerProviderMushroom.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/FlowerProviderNetherwart.java
+++ b/forestry_common/apiculture/forestry/apiculture/FlowerProviderNetherwart.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/FlowerProviderVanilla.java
+++ b/forestry_common/apiculture/forestry/apiculture/FlowerProviderVanilla.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/FlowerProviderWheat.java
+++ b/forestry_common/apiculture/forestry/apiculture/FlowerProviderWheat.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/GuiHandlerApiculture.java
+++ b/forestry_common/apiculture/forestry/apiculture/GuiHandlerApiculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/MaterialBeehive.java
+++ b/forestry_common/apiculture/forestry/apiculture/MaterialBeehive.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/PacketHandlerApiculture.java
+++ b/forestry_common/apiculture/forestry/apiculture/PacketHandlerApiculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/SaveEventHandlerApiculture.java
+++ b/forestry_common/apiculture/forestry/apiculture/SaveEventHandlerApiculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/SpeciesNotFoundException.java
+++ b/forestry_common/apiculture/forestry/apiculture/SpeciesNotFoundException.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/TemplateNotFoundException.java
+++ b/forestry_common/apiculture/forestry/apiculture/TemplateNotFoundException.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/VillageHandlerApiculture.java
+++ b/forestry_common/apiculture/forestry/apiculture/VillageHandlerApiculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/entities/EntityBee.java
+++ b/forestry_common/apiculture/forestry/apiculture/entities/EntityBee.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/BlockAlveary.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/BlockAlveary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/BlockBeehives.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/BlockBeehives.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/BlockCandle.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/BlockCandle.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/BlockStump.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/BlockStump.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/StructureLogicAlveary.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/StructureLogicAlveary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlveary.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlveary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyClimatiser.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyClimatiser.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyFan.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyFan.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyHeater.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyHeater.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyHygroregulator.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyHygroregulator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyPlain.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyPlain.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearySieve.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearySieve.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyStabiliser.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearyStabiliser.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearySwarmer.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileAlvearySwarmer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileApiaristChest.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileApiaristChest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileApiary.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileApiary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileBeehouse.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileBeehouse.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileCandle.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileCandle.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gadgets/TileSwarm.java
+++ b/forestry_common/apiculture/forestry/apiculture/gadgets/TileSwarm.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AIAvoidPlayers.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AIAvoidPlayers.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleBeeSpecies.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleBeeSpecies.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectAggressive.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectAggressive.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectCreeper.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectCreeper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectExploration.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectExploration.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectGlacial.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectGlacial.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectHeroic.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectHeroic.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectIgnition.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectIgnition.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectMiasmic.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectMiasmic.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectMisanthrope.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectMisanthrope.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectNone.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectNone.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectPotion.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectPotion.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectRadioactive.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectRadioactive.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectRepulsion.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectRepulsion.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectResurrection.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectResurrection.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectSnowing.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectSnowing.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectThrottled.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleEffectThrottled.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/AlleleFlowers.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/AlleleFlowers.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/ApiaristTracker.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/ApiaristTracker.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/Bee.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/Bee.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/BeeGenome.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/BeeGenome.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/BeeHelper.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/BeeHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/BeeMutation.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/BeeMutation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/BeeTemplates.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/BeeTemplates.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/BeekeepingMode.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/BeekeepingMode.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/BranchBees.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/BranchBees.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/HiveDrop.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/HiveDrop.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/IJubilanceProvider.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/IJubilanceProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/JubilanceDefault.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/JubilanceDefault.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/JubilanceNone.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/JubilanceNone.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/JubilanceProviderHermit.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/JubilanceProviderHermit.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/JubilanceReqRes.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/JubilanceReqRes.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/MutationEMC.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/MutationEMC.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/MutationReqRes.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/MutationReqRes.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/genetics/MutationTimeLimited.java
+++ b/forestry_common/apiculture/forestry/apiculture/genetics/MutationTimeLimited.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/ContainerAlveary.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/ContainerAlveary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/ContainerAlvearyHygroregulator.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/ContainerAlvearyHygroregulator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/ContainerAlvearySieve.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/ContainerAlvearySieve.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/ContainerAlvearySwarmer.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/ContainerAlvearySwarmer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/ContainerApiary.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/ContainerApiary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/ContainerBeealyzer.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/ContainerBeealyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/ContainerHabitatLocator.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/ContainerHabitatLocator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/ContainerImprinter.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/ContainerImprinter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/GuiAlveary.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/GuiAlveary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/GuiAlvearyHygroregulator.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/GuiAlvearyHygroregulator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/GuiAlvearySieve.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/GuiAlvearySieve.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/GuiAlvearySwarmer.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/GuiAlvearySwarmer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/GuiApiary.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/GuiApiary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/GuiBeealyzer.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/GuiBeealyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/GuiHabitatLocator.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/GuiHabitatLocator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/gui/GuiImprinter.java
+++ b/forestry_common/apiculture/forestry/apiculture/gui/GuiImprinter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemAlvearyBlock.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemAlvearyBlock.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemArmorApiarist.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemArmorApiarist.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemBeeGE.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemBeeGE.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemBeealyzer.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemBeealyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemBiomefinder.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemBiomefinder.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemCandleBlock.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemCandleBlock.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemHiveFrame.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemHiveFrame.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemHoneycomb.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemHoneycomb.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemImprinter.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemImprinter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/items/ItemWaxCast.java
+++ b/forestry_common/apiculture/forestry/apiculture/items/ItemWaxCast.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/proxy/ClientProxyApiculture.java
+++ b/forestry_common/apiculture/forestry/apiculture/proxy/ClientProxyApiculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/proxy/ProxyApiculture.java
+++ b/forestry_common/apiculture/forestry/apiculture/proxy/ProxyApiculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/render/BeeItemRenderer.java
+++ b/forestry_common/apiculture/forestry/apiculture/render/BeeItemRenderer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/render/BlockCandleRenderer.java
+++ b/forestry_common/apiculture/forestry/apiculture/render/BlockCandleRenderer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/render/EntityBeeFX.java
+++ b/forestry_common/apiculture/forestry/apiculture/render/EntityBeeFX.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/render/ModelAnalyzer.java
+++ b/forestry_common/apiculture/forestry/apiculture/render/ModelAnalyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/render/ModelBee.java
+++ b/forestry_common/apiculture/forestry/apiculture/render/ModelBee.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/render/ParticleRenderer.java
+++ b/forestry_common/apiculture/forestry/apiculture/render/ParticleRenderer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/render/RenderBee.java
+++ b/forestry_common/apiculture/forestry/apiculture/render/RenderBee.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/render/TextureBiomefinder.java
+++ b/forestry_common/apiculture/forestry/apiculture/render/TextureBiomefinder.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/trigger/TriggerNoFrames.java
+++ b/forestry_common/apiculture/forestry/apiculture/trigger/TriggerNoFrames.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/ComponentVillageBeeHouse.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/ComponentVillageBeeHouse.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/HiveDecorator.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/HiveDecorator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHive.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHive.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveEnd.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveEnd.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveForest.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveForest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveJungle.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveJungle.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveMeadows.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveMeadows.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveParched.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveParched.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveSnow.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveSnow.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveSwamer.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveSwamer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveSwamp.java
+++ b/forestry_common/apiculture/forestry/apiculture/worldgen/WorldGenHiveSwamp.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/plugins/PluginApiculture.java
+++ b/forestry_common/apiculture/forestry/plugins/PluginApiculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/apiculture/forestry/plugins/PluginEE.java
+++ b/forestry_common/apiculture/forestry/plugins/PluginEE.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/CommandSpawnForest.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/CommandSpawnForest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/CommandSpawnTree.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/CommandSpawnTree.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/CommandTreekeepingMode.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/CommandTreekeepingMode.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/EventHandlerArboriculture.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/EventHandlerArboriculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/FruitProviderNone.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/FruitProviderNone.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/FruitProviderPod.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/FruitProviderPod.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/FruitProviderRandom.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/FruitProviderRandom.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/FruitProviderRipening.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/FruitProviderRipening.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/GuiHandlerArboriculture.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/GuiHandlerArboriculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/IWoodTyped.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/IWoodTyped.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/PacketHandlerArboriculture.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/PacketHandlerArboriculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/VillageHandlerArboriculture.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/VillageHandlerArboriculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/WoodType.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/WoodType.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/WorldGenHelper.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/WorldGenHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockArbFence.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockArbFence.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockArbStairs.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockArbStairs.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockFruitPod.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockFruitPod.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockLeaves.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockLeaves.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockLog.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockLog.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockPlanks.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockPlanks.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockSapling.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockSapling.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockSlab.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockSlab.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockTreeContainer.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/BlockTreeContainer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileArboristChest.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileArboristChest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileFruitPod.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileFruitPod.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileLeaves.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileLeaves.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileSapling.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileSapling.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileStairs.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileStairs.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileTreeContainer.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gadgets/TileTreeContainer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/AlleleFruit.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/AlleleFruit.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/AlleleGrowth.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/AlleleGrowth.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/AlleleLeafEffectNone.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/AlleleLeafEffectNone.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/AlleleTreeSpecies.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/AlleleTreeSpecies.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/ArboristTracker.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/ArboristTracker.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/BranchTrees.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/BranchTrees.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/GrowthProvider.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/GrowthProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/GrowthProviderTropical.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/GrowthProviderTropical.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/Tree.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/Tree.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/TreeGenome.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/TreeGenome.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/TreeHelper.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/TreeHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/TreeMutation.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/TreeMutation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/TreeTemplates.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/TreeTemplates.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/genetics/TreekeepingMode.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/genetics/TreekeepingMode.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gui/ContainerTreealyzer.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gui/ContainerTreealyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/gui/GuiTreealyzer.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/gui/GuiTreealyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/items/ItemGermlingGE.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/items/ItemGermlingGE.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/items/ItemGrafter.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/items/ItemGrafter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/items/ItemStairs.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/items/ItemStairs.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/items/ItemTreealyzer.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/items/ItemTreealyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/items/ItemWoodBlock.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/items/ItemWoodBlock.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/network/PacketLeafUpdate.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/network/PacketLeafUpdate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/proxy/ClientProxyArboriculture.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/proxy/ClientProxyArboriculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/proxy/ProxyArboriculture.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/proxy/ProxyArboriculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/render/FenceRenderingHandler.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/render/FenceRenderingHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/render/FruitPodRenderingHandler.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/render/FruitPodRenderingHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/render/LeavesRenderingHandler.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/render/LeavesRenderingHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/render/SaplingRenderHandler.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/render/SaplingRenderHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/render/StairItemRenderer.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/render/StairItemRenderer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/BlockTypeLeaf.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/BlockTypeLeaf.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/BlockTypeVoid.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/BlockTypeVoid.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenAcacia.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenAcacia.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenAcaciaVanilla.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenAcaciaVanilla.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenArboriculture.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenArboriculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenBalsa.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenBalsa.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenBaobab.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenBaobab.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenBirch.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenBirch.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenCherry.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenCherry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenChestnut.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenChestnut.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenDarkOak.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenDarkOak.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenDate.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenDate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenEbony.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenEbony.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenGiganteum.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenGiganteum.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenGreenheart.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenGreenheart.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenJungle.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenJungle.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenKapok.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenKapok.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenLarch.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenLarch.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenLemon.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenLemon.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenLime.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenLime.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenMahoe.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenMahoe.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenMahogany.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenMahogany.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenMaple.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenMaple.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenOak.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenOak.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenPapaya.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenPapaya.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenPine.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenPine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenPlum.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenPlum.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenPoplar.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenPoplar.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenSequoia.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenSequoia.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenSpruce.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenSpruce.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenTeak.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenTeak.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenTree.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenTree.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenWalnut.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenWalnut.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenWenge.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenWenge.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenWillow.java
+++ b/forestry_common/arboriculture/forestry/arboriculture/worldgen/WorldGenWillow.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/arboriculture/forestry/plugins/PluginArboriculture.java
+++ b/forestry_common/arboriculture/forestry/plugins/PluginArboriculture.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/Forestry.java
+++ b/forestry_common/core/forestry/Forestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/CommandForestry.java
+++ b/forestry_common/core/forestry/core/CommandForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/CreativeTabForestry.java
+++ b/forestry_common/core/forestry/core/CreativeTabForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/EnumErrorCode.java
+++ b/forestry_common/core/forestry/core/EnumErrorCode.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/EventHandlerCore.java
+++ b/forestry_common/core/forestry/core/EventHandlerCore.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/ForestryClient.java
+++ b/forestry_common/core/forestry/core/ForestryClient.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/ForestryConstants.java
+++ b/forestry_common/core/forestry/core/ForestryConstants.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/ForestryCore.java
+++ b/forestry_common/core/forestry/core/ForestryCore.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/GameMode.java
+++ b/forestry_common/core/forestry/core/GameMode.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/GuiHandler.java
+++ b/forestry_common/core/forestry/core/GuiHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/GuiHandlerBase.java
+++ b/forestry_common/core/forestry/core/GuiHandlerBase.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/PickupHandlerCore.java
+++ b/forestry_common/core/forestry/core/PickupHandlerCore.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/SaveEventHandlerCore.java
+++ b/forestry_common/core/forestry/core/SaveEventHandlerCore.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/TemperatureState.java
+++ b/forestry_common/core/forestry/core/TemperatureState.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/TickHandlerCoreClient.java
+++ b/forestry_common/core/forestry/core/TickHandlerCoreClient.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/TickHandlerCoreServer.java
+++ b/forestry_common/core/forestry/core/TickHandlerCoreServer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/WorldGenerator.java
+++ b/forestry_common/core/forestry/core/WorldGenerator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/Circuit.java
+++ b/forestry_common/core/forestry/core/circuits/Circuit.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/CircuitBoard.java
+++ b/forestry_common/core/forestry/core/circuits/CircuitBoard.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/CircuitBoardManager.java
+++ b/forestry_common/core/forestry/core/circuits/CircuitBoardManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/CircuitId.java
+++ b/forestry_common/core/forestry/core/circuits/CircuitId.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/CircuitLayout.java
+++ b/forestry_common/core/forestry/core/circuits/CircuitLayout.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/CircuitLibrary.java
+++ b/forestry_common/core/forestry/core/circuits/CircuitLibrary.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/CircuitRegistry.java
+++ b/forestry_common/core/forestry/core/circuits/CircuitRegistry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/ContainerSolderingIron.java
+++ b/forestry_common/core/forestry/core/circuits/ContainerSolderingIron.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/EnumCircuitBoardType.java
+++ b/forestry_common/core/forestry/core/circuits/EnumCircuitBoardType.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/GuiSolderingIron.java
+++ b/forestry_common/core/forestry/core/circuits/GuiSolderingIron.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/ISolderingIron.java
+++ b/forestry_common/core/forestry/core/circuits/ISolderingIron.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/ItemCircuitBoard.java
+++ b/forestry_common/core/forestry/core/circuits/ItemCircuitBoard.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/circuits/ItemSolderingIron.java
+++ b/forestry_common/core/forestry/core/circuits/ItemSolderingIron.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/config/Config.java
+++ b/forestry_common/core/forestry/core/config/Config.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/config/Configuration.java
+++ b/forestry_common/core/forestry/core/config/Configuration.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/config/Defaults.java
+++ b/forestry_common/core/forestry/core/config/Defaults.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/config/ForestryBlock.java
+++ b/forestry_common/core/forestry/core/config/ForestryBlock.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/config/ForestryItem.java
+++ b/forestry_common/core/forestry/core/config/ForestryItem.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/config/Property.java
+++ b/forestry_common/core/forestry/core/config/Property.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/config/SessionVars.java
+++ b/forestry_common/core/forestry/core/config/SessionVars.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/config/Version.java
+++ b/forestry_common/core/forestry/core/config/Version.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/BlockBase.java
+++ b/forestry_common/core/forestry/core/gadgets/BlockBase.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/BlockForestry.java
+++ b/forestry_common/core/forestry/core/gadgets/BlockForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/BlockResource.java
+++ b/forestry_common/core/forestry/core/gadgets/BlockResource.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/BlockSoil.java
+++ b/forestry_common/core/forestry/core/gadgets/BlockSoil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/BlockStainedGlass.java
+++ b/forestry_common/core/forestry/core/gadgets/BlockStainedGlass.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/BlockStructure.java
+++ b/forestry_common/core/forestry/core/gadgets/BlockStructure.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/Engine.java
+++ b/forestry_common/core/forestry/core/gadgets/Engine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/IStructureBlockItem.java
+++ b/forestry_common/core/forestry/core/gadgets/IStructureBlockItem.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/MachineDefinition.java
+++ b/forestry_common/core/forestry/core/gadgets/MachineDefinition.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/MachineNBTDefinition.java
+++ b/forestry_common/core/forestry/core/gadgets/MachineNBTDefinition.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/Mill.java
+++ b/forestry_common/core/forestry/core/gadgets/Mill.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/NaturalistGame.java
+++ b/forestry_common/core/forestry/core/gadgets/NaturalistGame.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/StructureLogic.java
+++ b/forestry_common/core/forestry/core/gadgets/StructureLogic.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TileAnalyzer.java
+++ b/forestry_common/core/forestry/core/gadgets/TileAnalyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TileBase.java
+++ b/forestry_common/core/forestry/core/gadgets/TileBase.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TileEngine.java
+++ b/forestry_common/core/forestry/core/gadgets/TileEngine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TileEscritoire.java
+++ b/forestry_common/core/forestry/core/gadgets/TileEscritoire.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TileForestry.java
+++ b/forestry_common/core/forestry/core/gadgets/TileForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TileMachine.java
+++ b/forestry_common/core/forestry/core/gadgets/TileMachine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TileMill.java
+++ b/forestry_common/core/forestry/core/gadgets/TileMill.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TileNaturalistChest.java
+++ b/forestry_common/core/forestry/core/gadgets/TileNaturalistChest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gadgets/TilePowered.java
+++ b/forestry_common/core/forestry/core/gadgets/TilePowered.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/Allele.java
+++ b/forestry_common/core/forestry/core/genetics/Allele.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/AlleleArea.java
+++ b/forestry_common/core/forestry/core/genetics/AlleleArea.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/AlleleBoolean.java
+++ b/forestry_common/core/forestry/core/genetics/AlleleBoolean.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/AlleleFloat.java
+++ b/forestry_common/core/forestry/core/genetics/AlleleFloat.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/AlleleInteger.java
+++ b/forestry_common/core/forestry/core/genetics/AlleleInteger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/AllelePlantType.java
+++ b/forestry_common/core/forestry/core/genetics/AllelePlantType.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/AlleleRegistry.java
+++ b/forestry_common/core/forestry/core/genetics/AlleleRegistry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/AlleleSpecies.java
+++ b/forestry_common/core/forestry/core/genetics/AlleleSpecies.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/AlleleTolerance.java
+++ b/forestry_common/core/forestry/core/genetics/AlleleTolerance.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/Branch.java
+++ b/forestry_common/core/forestry/core/genetics/Branch.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/BreedingTracker.java
+++ b/forestry_common/core/forestry/core/genetics/BreedingTracker.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/Chromosome.java
+++ b/forestry_common/core/forestry/core/genetics/Chromosome.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/Classification.java
+++ b/forestry_common/core/forestry/core/genetics/Classification.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/ClimateHelper.java
+++ b/forestry_common/core/forestry/core/genetics/ClimateHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/EffectData.java
+++ b/forestry_common/core/forestry/core/genetics/EffectData.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/EnumMutateChance.java
+++ b/forestry_common/core/forestry/core/genetics/EnumMutateChance.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/FruitFamily.java
+++ b/forestry_common/core/forestry/core/genetics/FruitFamily.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/GenericRatings.java
+++ b/forestry_common/core/forestry/core/genetics/GenericRatings.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/Genome.java
+++ b/forestry_common/core/forestry/core/genetics/Genome.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/Individual.java
+++ b/forestry_common/core/forestry/core/genetics/Individual.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/IndividualLiving.java
+++ b/forestry_common/core/forestry/core/genetics/IndividualLiving.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/ItemGE.java
+++ b/forestry_common/core/forestry/core/genetics/ItemGE.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/ItemResearchNote.java
+++ b/forestry_common/core/forestry/core/genetics/ItemResearchNote.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/Mutation.java
+++ b/forestry_common/core/forestry/core/genetics/Mutation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/genetics/SpeciesRoot.java
+++ b/forestry_common/core/forestry/core/genetics/SpeciesRoot.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ClimateLedger.java
+++ b/forestry_common/core/forestry/core/gui/ClimateLedger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ContainerAnalyzer.java
+++ b/forestry_common/core/forestry/core/gui/ContainerAnalyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ContainerDummy.java
+++ b/forestry_common/core/forestry/core/gui/ContainerDummy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ContainerEscritoire.java
+++ b/forestry_common/core/forestry/core/gui/ContainerEscritoire.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ContainerForestry.java
+++ b/forestry_common/core/forestry/core/gui/ContainerForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ContainerItemInventory.java
+++ b/forestry_common/core/forestry/core/gui/ContainerItemInventory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ContainerLiquidTanks.java
+++ b/forestry_common/core/forestry/core/gui/ContainerLiquidTanks.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ContainerNaturalistInventory.java
+++ b/forestry_common/core/forestry/core/gui/ContainerNaturalistInventory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ContainerSocketed.java
+++ b/forestry_common/core/forestry/core/gui/ContainerSocketed.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/ErrorLedger.java
+++ b/forestry_common/core/forestry/core/gui/ErrorLedger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/GuiAlyzer.java
+++ b/forestry_common/core/forestry/core/gui/GuiAlyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/GuiAnalyzer.java
+++ b/forestry_common/core/forestry/core/gui/GuiAnalyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/GuiEscritoire.java
+++ b/forestry_common/core/forestry/core/gui/GuiEscritoire.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/GuiForestry.java
+++ b/forestry_common/core/forestry/core/gui/GuiForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/GuiNaturalistInventory.java
+++ b/forestry_common/core/forestry/core/gui/GuiNaturalistInventory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/GuiTextBox.java
+++ b/forestry_common/core/forestry/core/gui/GuiTextBox.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/HintLedger.java
+++ b/forestry_common/core/forestry/core/gui/HintLedger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/IGuiSelectable.java
+++ b/forestry_common/core/forestry/core/gui/IGuiSelectable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/IPagedInventory.java
+++ b/forestry_common/core/forestry/core/gui/IPagedInventory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/Ledger.java
+++ b/forestry_common/core/forestry/core/gui/Ledger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/LedgerManager.java
+++ b/forestry_common/core/forestry/core/gui/LedgerManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/OwnerLedger.java
+++ b/forestry_common/core/forestry/core/gui/OwnerLedger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/PlainLedger.java
+++ b/forestry_common/core/forestry/core/gui/PlainLedger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/PowerLedger.java
+++ b/forestry_common/core/forestry/core/gui/PowerLedger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/WidgetManager.java
+++ b/forestry_common/core/forestry/core/gui/WidgetManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/ButtonTextureSet.java
+++ b/forestry_common/core/forestry/core/gui/buttons/ButtonTextureSet.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/GuiBetterButton.java
+++ b/forestry_common/core/forestry/core/gui/buttons/GuiBetterButton.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/GuiButtonSmall.java
+++ b/forestry_common/core/forestry/core/gui/buttons/GuiButtonSmall.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/GuiMultiButton.java
+++ b/forestry_common/core/forestry/core/gui/buttons/GuiMultiButton.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/GuiToggleButton.java
+++ b/forestry_common/core/forestry/core/gui/buttons/GuiToggleButton.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/GuiToggleButtonSmall.java
+++ b/forestry_common/core/forestry/core/gui/buttons/GuiToggleButtonSmall.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/IButtonTextureSet.java
+++ b/forestry_common/core/forestry/core/gui/buttons/IButtonTextureSet.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/IMultiButtonState.java
+++ b/forestry_common/core/forestry/core/gui/buttons/IMultiButtonState.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/LockButtonState.java
+++ b/forestry_common/core/forestry/core/gui/buttons/LockButtonState.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/MultiButtonController.java
+++ b/forestry_common/core/forestry/core/gui/buttons/MultiButtonController.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/buttons/StandardButtonTextureSets.java
+++ b/forestry_common/core/forestry/core/gui/buttons/StandardButtonTextureSets.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotClosed.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotClosed.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotCraftAuto.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotCraftAuto.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotCrafter.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotCrafter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotCustom.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotCustom.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotForestry.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotItemInventory.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotItemInventory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotLiquidContainer.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotLiquidContainer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotLocked.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotLocked.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotOutput.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotOutput.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/slots/SlotWorking.java
+++ b/forestry_common/core/forestry/core/gui/slots/SlotWorking.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/tooltips/IToolTipProvider.java
+++ b/forestry_common/core/forestry/core/gui/tooltips/IToolTipProvider.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/tooltips/ToolTip.java
+++ b/forestry_common/core/forestry/core/gui/tooltips/ToolTip.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/tooltips/ToolTipLine.java
+++ b/forestry_common/core/forestry/core/gui/tooltips/ToolTipLine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/widgets/ReservoirWidget.java
+++ b/forestry_common/core/forestry/core/gui/widgets/ReservoirWidget.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/widgets/SocketWidget.java
+++ b/forestry_common/core/forestry/core/gui/widgets/SocketWidget.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/widgets/TankWidget.java
+++ b/forestry_common/core/forestry/core/gui/widgets/TankWidget.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/gui/widgets/Widget.java
+++ b/forestry_common/core/forestry/core/gui/widgets/Widget.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IBlockRenderer.java
+++ b/forestry_common/core/forestry/core/interfaces/IBlockRenderer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IClimatised.java
+++ b/forestry_common/core/forestry/core/interfaces/IClimatised.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IContainerCrafting.java
+++ b/forestry_common/core/forestry/core/interfaces/IContainerCrafting.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/ICrafter.java
+++ b/forestry_common/core/forestry/core/interfaces/ICrafter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/ICraftingPlan.java
+++ b/forestry_common/core/forestry/core/interfaces/ICraftingPlan.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IDescriptiveRecipe.java
+++ b/forestry_common/core/forestry/core/interfaces/IDescriptiveRecipe.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IErrorSource.java
+++ b/forestry_common/core/forestry/core/interfaces/IErrorSource.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IHintSource.java
+++ b/forestry_common/core/forestry/core/interfaces/IHintSource.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IInventoriedItem.java
+++ b/forestry_common/core/forestry/core/interfaces/IInventoriedItem.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/ILiquidTankContainer.java
+++ b/forestry_common/core/forestry/core/interfaces/ILiquidTankContainer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IOreDictionaryHandler.java
+++ b/forestry_common/core/forestry/core/interfaces/IOreDictionaryHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IOwnable.java
+++ b/forestry_common/core/forestry/core/interfaces/IOwnable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IPacketHandler.java
+++ b/forestry_common/core/forestry/core/interfaces/IPacketHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IPickupHandler.java
+++ b/forestry_common/core/forestry/core/interfaces/IPickupHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IPowerHandler.java
+++ b/forestry_common/core/forestry/core/interfaces/IPowerHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IRenderableMachine.java
+++ b/forestry_common/core/forestry/core/interfaces/IRenderableMachine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/IResupplyHandler.java
+++ b/forestry_common/core/forestry/core/interfaces/IResupplyHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/ISaveEventHandler.java
+++ b/forestry_common/core/forestry/core/interfaces/ISaveEventHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/interfaces/ISocketable.java
+++ b/forestry_common/core/forestry/core/interfaces/ISocketable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/ITileFilter.java
+++ b/forestry_common/core/forestry/core/inventory/ITileFilter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/InvTools.java
+++ b/forestry_common/core/forestry/core/inventory/InvTools.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/InventoryConcatenator.java
+++ b/forestry_common/core/forestry/core/inventory/InventoryConcatenator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/InventorySorter.java
+++ b/forestry_common/core/forestry/core/inventory/InventorySorter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/ItemStackMap.java
+++ b/forestry_common/core/forestry/core/inventory/ItemStackMap.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/ItemStackSet.java
+++ b/forestry_common/core/forestry/core/inventory/ItemStackSet.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/ItemStackSizeSorter.java
+++ b/forestry_common/core/forestry/core/inventory/ItemStackSizeSorter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/filters/ArrayStackFilter.java
+++ b/forestry_common/core/forestry/core/inventory/filters/ArrayStackFilter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/filters/IStackFilter.java
+++ b/forestry_common/core/forestry/core/inventory/filters/IStackFilter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/filters/InvertedStackFilter.java
+++ b/forestry_common/core/forestry/core/inventory/filters/InvertedStackFilter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/filters/StackFilter.java
+++ b/forestry_common/core/forestry/core/inventory/filters/StackFilter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/manipulators/InventoryManipulator.java
+++ b/forestry_common/core/forestry/core/inventory/manipulators/InventoryManipulator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/manipulators/SpecialManipulator.java
+++ b/forestry_common/core/forestry/core/inventory/manipulators/SpecialManipulator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/wrappers/ChestWrapper.java
+++ b/forestry_common/core/forestry/core/inventory/wrappers/ChestWrapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/wrappers/IInvSlot.java
+++ b/forestry_common/core/forestry/core/inventory/wrappers/IInvSlot.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/wrappers/InventoryCopy.java
+++ b/forestry_common/core/forestry/core/inventory/wrappers/InventoryCopy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/wrappers/InventoryIterator.java
+++ b/forestry_common/core/forestry/core/inventory/wrappers/InventoryIterator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/wrappers/InventoryMapper.java
+++ b/forestry_common/core/forestry/core/inventory/wrappers/InventoryMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/wrappers/SidedInventoryIterator.java
+++ b/forestry_common/core/forestry/core/inventory/wrappers/SidedInventoryIterator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/wrappers/SidedInventoryMapper.java
+++ b/forestry_common/core/forestry/core/inventory/wrappers/SidedInventoryMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/inventory/wrappers/SpecialInventoryMapper.java
+++ b/forestry_common/core/forestry/core/inventory/wrappers/SpecialInventoryMapper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemArmorNaturalist.java
+++ b/forestry_common/core/forestry/core/items/ItemArmorNaturalist.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemAssemblyKit.java
+++ b/forestry_common/core/forestry/core/items/ItemAssemblyKit.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemCrated.java
+++ b/forestry_common/core/forestry/core/items/ItemCrated.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemForestry.java
+++ b/forestry_common/core/forestry/core/items/ItemForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemForestryBlock.java
+++ b/forestry_common/core/forestry/core/items/ItemForestryBlock.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemForestryFood.java
+++ b/forestry_common/core/forestry/core/items/ItemForestryFood.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemForestryPickaxe.java
+++ b/forestry_common/core/forestry/core/items/ItemForestryPickaxe.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemForestryShovel.java
+++ b/forestry_common/core/forestry/core/items/ItemForestryShovel.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemForestryTool.java
+++ b/forestry_common/core/forestry/core/items/ItemForestryTool.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemFruit.java
+++ b/forestry_common/core/forestry/core/items/ItemFruit.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemInventoried.java
+++ b/forestry_common/core/forestry/core/items/ItemInventoried.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemLiquidContainer.java
+++ b/forestry_common/core/forestry/core/items/ItemLiquidContainer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemLiquids.java
+++ b/forestry_common/core/forestry/core/items/ItemLiquids.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemMisc.java
+++ b/forestry_common/core/forestry/core/items/ItemMisc.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemNBTTile.java
+++ b/forestry_common/core/forestry/core/items/ItemNBTTile.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemOverlay.java
+++ b/forestry_common/core/forestry/core/items/ItemOverlay.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemPipette.java
+++ b/forestry_common/core/forestry/core/items/ItemPipette.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemScoop.java
+++ b/forestry_common/core/forestry/core/items/ItemScoop.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/items/ItemWrench.java
+++ b/forestry_common/core/forestry/core/items/ItemWrench.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/ClassMap.java
+++ b/forestry_common/core/forestry/core/network/ClassMap.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/EntityNetData.java
+++ b/forestry_common/core/forestry/core/network/EntityNetData.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/ForestryPacket.java
+++ b/forestry_common/core/forestry/core/network/ForestryPacket.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/GuiId.java
+++ b/forestry_common/core/forestry/core/network/GuiId.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/ILocatedPacket.java
+++ b/forestry_common/core/forestry/core/network/ILocatedPacket.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/INetworkedEntity.java
+++ b/forestry_common/core/forestry/core/network/INetworkedEntity.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/IndexInPayload.java
+++ b/forestry_common/core/forestry/core/network/IndexInPayload.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketCoordinates.java
+++ b/forestry_common/core/forestry/core/network/PacketCoordinates.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketFXSignal.java
+++ b/forestry_common/core/forestry/core/network/PacketFXSignal.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketHandler.java
+++ b/forestry_common/core/forestry/core/network/PacketHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketIds.java
+++ b/forestry_common/core/forestry/core/network/PacketIds.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketInventoryStack.java
+++ b/forestry_common/core/forestry/core/network/PacketInventoryStack.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketNBT.java
+++ b/forestry_common/core/forestry/core/network/PacketNBT.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketPayload.java
+++ b/forestry_common/core/forestry/core/network/PacketPayload.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketSocketUpdate.java
+++ b/forestry_common/core/forestry/core/network/PacketSocketUpdate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketTankUpdate.java
+++ b/forestry_common/core/forestry/core/network/PacketTankUpdate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketTileNBT.java
+++ b/forestry_common/core/forestry/core/network/PacketTileNBT.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketTileUpdate.java
+++ b/forestry_common/core/forestry/core/network/PacketTileUpdate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/network/PacketUpdate.java
+++ b/forestry_common/core/forestry/core/network/PacketUpdate.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/proxy/ClientProxyCommon.java
+++ b/forestry_common/core/forestry/core/proxy/ClientProxyCommon.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/proxy/ClientProxyNetwork.java
+++ b/forestry_common/core/forestry/core/proxy/ClientProxyNetwork.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/proxy/ClientProxyRender.java
+++ b/forestry_common/core/forestry/core/proxy/ClientProxyRender.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/proxy/Proxies.java
+++ b/forestry_common/core/forestry/core/proxy/Proxies.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/proxy/ProxyCommon.java
+++ b/forestry_common/core/forestry/core/proxy/ProxyCommon.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/proxy/ProxyLog.java
+++ b/forestry_common/core/forestry/core/proxy/ProxyLog.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/proxy/ProxyNetwork.java
+++ b/forestry_common/core/forestry/core/proxy/ProxyNetwork.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/proxy/ProxyRender.java
+++ b/forestry_common/core/forestry/core/proxy/ProxyRender.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/BlockRenderingHandler.java
+++ b/forestry_common/core/forestry/core/render/BlockRenderingHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/EntityBiodustFX.java
+++ b/forestry_common/core/forestry/core/render/EntityBiodustFX.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/EntityHoneydustFX.java
+++ b/forestry_common/core/forestry/core/render/EntityHoneydustFX.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/EntitySnowFX.java
+++ b/forestry_common/core/forestry/core/render/EntitySnowFX.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/ModelEscritoire.java
+++ b/forestry_common/core/forestry/core/render/ModelEscritoire.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/OverlayRenderingHandler.java
+++ b/forestry_common/core/forestry/core/render/OverlayRenderingHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/RenderAnalyzer.java
+++ b/forestry_common/core/forestry/core/render/RenderAnalyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/RenderEscritoire.java
+++ b/forestry_common/core/forestry/core/render/RenderEscritoire.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/RenderMachine.java
+++ b/forestry_common/core/forestry/core/render/RenderMachine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/RenderMill.java
+++ b/forestry_common/core/forestry/core/render/RenderMill.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/SpriteSheet.java
+++ b/forestry_common/core/forestry/core/render/SpriteSheet.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/TextureManager.java
+++ b/forestry_common/core/forestry/core/render/TextureManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/render/TileRendererIndex.java
+++ b/forestry_common/core/forestry/core/render/TileRendererIndex.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/ForestryTrigger.java
+++ b/forestry_common/core/forestry/core/triggers/ForestryTrigger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/Trigger.java
+++ b/forestry_common/core/forestry/core/triggers/Trigger.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/TriggerHasWork.java
+++ b/forestry_common/core/forestry/core/triggers/TriggerHasWork.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/TriggerLowFuel.java
+++ b/forestry_common/core/forestry/core/triggers/TriggerLowFuel.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/TriggerLowGermlings.java
+++ b/forestry_common/core/forestry/core/triggers/TriggerLowGermlings.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/TriggerLowResource.java
+++ b/forestry_common/core/forestry/core/triggers/TriggerLowResource.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/TriggerLowSoil.java
+++ b/forestry_common/core/forestry/core/triggers/TriggerLowSoil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/TriggerMissingDrone.java
+++ b/forestry_common/core/forestry/core/triggers/TriggerMissingDrone.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/triggers/TriggerMissingQueen.java
+++ b/forestry_common/core/forestry/core/triggers/TriggerMissingQueen.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/BlockUtil.java
+++ b/forestry_common/core/forestry/core/utils/BlockUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/CommandMC.java
+++ b/forestry_common/core/forestry/core/utils/CommandMC.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/DamageSourceForestry.java
+++ b/forestry_common/core/forestry/core/utils/DamageSourceForestry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/DelayTimer.java
+++ b/forestry_common/core/forestry/core/utils/DelayTimer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/EnumAccess.java
+++ b/forestry_common/core/forestry/core/utils/EnumAccess.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/EnumTankLevel.java
+++ b/forestry_common/core/forestry/core/utils/EnumTankLevel.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/FluidMap.java
+++ b/forestry_common/core/forestry/core/utils/FluidMap.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/FluidStackMap.java
+++ b/forestry_common/core/forestry/core/utils/FluidStackMap.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/Fluids.java
+++ b/forestry_common/core/forestry/core/utils/Fluids.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/FontColour.java
+++ b/forestry_common/core/forestry/core/utils/FontColour.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/ForestryModEnvWarningCallable.java
+++ b/forestry_common/core/forestry/core/utils/ForestryModEnvWarningCallable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/ForestryResource.java
+++ b/forestry_common/core/forestry/core/utils/ForestryResource.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/ForestryTank.java
+++ b/forestry_common/core/forestry/core/utils/ForestryTank.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/IDAllocator.java
+++ b/forestry_common/core/forestry/core/utils/IDAllocator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/InventoryAdapter.java
+++ b/forestry_common/core/forestry/core/utils/InventoryAdapter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/ItemInventory.java
+++ b/forestry_common/core/forestry/core/utils/ItemInventory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/ItemStackMap.java
+++ b/forestry_common/core/forestry/core/utils/ItemStackMap.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/LiquidHelper.java
+++ b/forestry_common/core/forestry/core/utils/LiquidHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/Localization.java
+++ b/forestry_common/core/forestry/core/utils/Localization.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/PlainInventory.java
+++ b/forestry_common/core/forestry/core/utils/PlainInventory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/RecipeUtil.java
+++ b/forestry_common/core/forestry/core/utils/RecipeUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/Schemata.java
+++ b/forestry_common/core/forestry/core/utils/Schemata.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/ShapedRecipeCustom.java
+++ b/forestry_common/core/forestry/core/utils/ShapedRecipeCustom.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/StackMap.java
+++ b/forestry_common/core/forestry/core/utils/StackMap.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/StackUtils.java
+++ b/forestry_common/core/forestry/core/utils/StackUtils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/StringUtil.java
+++ b/forestry_common/core/forestry/core/utils/StringUtil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/TileInventoryAdapter.java
+++ b/forestry_common/core/forestry/core/utils/TileInventoryAdapter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/Utils.java
+++ b/forestry_common/core/forestry/core/utils/Utils.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/utils/Vect.java
+++ b/forestry_common/core/forestry/core/utils/Vect.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/worldgen/BlockType.java
+++ b/forestry_common/core/forestry/core/worldgen/BlockType.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/worldgen/WorldGenBase.java
+++ b/forestry_common/core/forestry/core/worldgen/WorldGenBase.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/core/worldgen/WorldGenMinableMeta.java
+++ b/forestry_common/core/forestry/core/worldgen/WorldGenMinableMeta.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/plugins/NativePlugin.java
+++ b/forestry_common/core/forestry/plugins/NativePlugin.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/plugins/PluginBuildCraft.java
+++ b/forestry_common/core/forestry/plugins/PluginBuildCraft.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/plugins/PluginCore.java
+++ b/forestry_common/core/forestry/plugins/PluginCore.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/plugins/PluginIC2.java
+++ b/forestry_common/core/forestry/plugins/PluginIC2.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/core/forestry/plugins/PluginManager.java
+++ b/forestry_common/core/forestry/plugins/PluginManager.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/GuiHandlerEnergy.java
+++ b/forestry_common/energy/forestry/energy/GuiHandlerEnergy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/circuits/CircuitElectricBoost.java
+++ b/forestry_common/energy/forestry/energy/circuits/CircuitElectricBoost.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/circuits/CircuitElectricChange.java
+++ b/forestry_common/energy/forestry/energy/circuits/CircuitElectricChange.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/circuits/CircuitElectricChoke.java
+++ b/forestry_common/energy/forestry/energy/circuits/CircuitElectricChoke.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/circuits/CircuitElectricEfficiency.java
+++ b/forestry_common/energy/forestry/energy/circuits/CircuitElectricEfficiency.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/circuits/CircuitFireDampener.java
+++ b/forestry_common/energy/forestry/energy/circuits/CircuitFireDampener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gadgets/EngineBronze.java
+++ b/forestry_common/energy/forestry/energy/gadgets/EngineBronze.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gadgets/EngineClockwork.java
+++ b/forestry_common/energy/forestry/energy/gadgets/EngineClockwork.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gadgets/EngineCopper.java
+++ b/forestry_common/energy/forestry/energy/gadgets/EngineCopper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gadgets/EngineDefinition.java
+++ b/forestry_common/energy/forestry/energy/gadgets/EngineDefinition.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gadgets/EngineTin.java
+++ b/forestry_common/energy/forestry/energy/gadgets/EngineTin.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gadgets/MachineGenerator.java
+++ b/forestry_common/energy/forestry/energy/gadgets/MachineGenerator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/ContainerEngineBronze.java
+++ b/forestry_common/energy/forestry/energy/gui/ContainerEngineBronze.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/ContainerEngineCopper.java
+++ b/forestry_common/energy/forestry/energy/gui/ContainerEngineCopper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/ContainerEngineTin.java
+++ b/forestry_common/energy/forestry/energy/gui/ContainerEngineTin.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/ContainerGenerator.java
+++ b/forestry_common/energy/forestry/energy/gui/ContainerGenerator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/GuiEngine.java
+++ b/forestry_common/energy/forestry/energy/gui/GuiEngine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/GuiEngineBronze.java
+++ b/forestry_common/energy/forestry/energy/gui/GuiEngineBronze.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/GuiEngineCopper.java
+++ b/forestry_common/energy/forestry/energy/gui/GuiEngineCopper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/GuiEngineTin.java
+++ b/forestry_common/energy/forestry/energy/gui/GuiEngineTin.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/gui/GuiGenerator.java
+++ b/forestry_common/energy/forestry/energy/gui/GuiGenerator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/proxy/ClientProxyEnergy.java
+++ b/forestry_common/energy/forestry/energy/proxy/ClientProxyEnergy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/proxy/ProxyEnergy.java
+++ b/forestry_common/energy/forestry/energy/proxy/ProxyEnergy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/energy/render/RenderEngine.java
+++ b/forestry_common/energy/forestry/energy/render/RenderEngine.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/energy/forestry/plugins/PluginEnergy.java
+++ b/forestry_common/energy/forestry/plugins/PluginEnergy.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/GuiHandlerFactory.java
+++ b/forestry_common/factory/forestry/factory/GuiHandlerFactory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineBottler.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineBottler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineCarpenter.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineCarpenter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineCentrifuge.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineCentrifuge.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineFabricator.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineFabricator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineFermenter.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineFermenter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineMoistener.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineMoistener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineRaintank.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineRaintank.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineSqueezer.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineSqueezer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MachineStill.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MachineStill.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/MillRainmaker.java
+++ b/forestry_common/factory/forestry/factory/gadgets/MillRainmaker.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gadgets/TileWorktable.java
+++ b/forestry_common/factory/forestry/factory/gadgets/TileWorktable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerBottler.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerBottler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerCarpenter.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerCarpenter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerCentrifuge.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerCentrifuge.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerFabricator.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerFabricator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerFermenter.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerFermenter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerMoistener.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerMoistener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerRaintank.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerRaintank.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerSqueezer.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerSqueezer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerStill.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerStill.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/ContainerWorktable.java
+++ b/forestry_common/factory/forestry/factory/gui/ContainerWorktable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiBottler.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiBottler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiCarpenter.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiCarpenter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiCentrifuge.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiCentrifuge.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiFabricator.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiFabricator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiFermenter.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiFermenter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiMoistener.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiMoistener.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiRaintank.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiRaintank.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiSqueezer.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiSqueezer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiStill.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiStill.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/GuiWorktable.java
+++ b/forestry_common/factory/forestry/factory/gui/GuiWorktable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/InventoryCraftingAuto.java
+++ b/forestry_common/factory/forestry/factory/gui/InventoryCraftingAuto.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/gui/SlotCraftMatrix.java
+++ b/forestry_common/factory/forestry/factory/gui/SlotCraftMatrix.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideBottler.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideBottler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideCarpenter.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideCarpenter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideCentrifuge.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideCentrifuge.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideCustomRecipes.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideCustomRecipes.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideFabricator.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideFabricator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideFermenter.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideFermenter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideIntegration.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideIntegration.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideSqueezer.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideSqueezer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/factory/recipes/CraftGuideStill.java
+++ b/forestry_common/factory/forestry/factory/recipes/CraftGuideStill.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/factory/forestry/plugins/PluginFactory.java
+++ b/forestry_common/factory/forestry/plugins/PluginFactory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/EventHandlerFarming.java
+++ b/forestry_common/farming/forestry/farming/EventHandlerFarming.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/FarmHelper.java
+++ b/forestry_common/farming/forestry/farming/FarmHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/FarmTarget.java
+++ b/forestry_common/farming/forestry/farming/FarmTarget.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/GuiHandlerFarming.java
+++ b/forestry_common/farming/forestry/farming/GuiHandlerFarming.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/circuits/CircuitFarmLogic.java
+++ b/forestry_common/farming/forestry/farming/circuits/CircuitFarmLogic.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/BlockFarm.java
+++ b/forestry_common/farming/forestry/farming/gadgets/BlockFarm.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/BlockMushroom.java
+++ b/forestry_common/farming/forestry/farming/gadgets/BlockMushroom.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/StructureLogicFarm.java
+++ b/forestry_common/farming/forestry/farming/gadgets/StructureLogicFarm.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/TileControl.java
+++ b/forestry_common/farming/forestry/farming/gadgets/TileControl.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/TileFarm.java
+++ b/forestry_common/farming/forestry/farming/gadgets/TileFarm.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/TileFarmPlain.java
+++ b/forestry_common/farming/forestry/farming/gadgets/TileFarmPlain.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/TileGearbox.java
+++ b/forestry_common/farming/forestry/farming/gadgets/TileGearbox.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/TileHatch.java
+++ b/forestry_common/farming/forestry/farming/gadgets/TileHatch.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gadgets/TileValve.java
+++ b/forestry_common/farming/forestry/farming/gadgets/TileValve.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gui/ContainerFarm.java
+++ b/forestry_common/farming/forestry/farming/gui/ContainerFarm.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/gui/GuiFarm.java
+++ b/forestry_common/farming/forestry/farming/gui/GuiFarm.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/items/ItemFarmBlock.java
+++ b/forestry_common/farming/forestry/farming/items/ItemFarmBlock.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/Crop.java
+++ b/forestry_common/farming/forestry/farming/logic/Crop.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/CropBlock.java
+++ b/forestry_common/farming/forestry/farming/logic/CropBlock.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/CropFruit.java
+++ b/forestry_common/farming/forestry/farming/logic/CropFruit.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/CropPeat.java
+++ b/forestry_common/farming/forestry/farming/logic/CropPeat.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/CropRubber.java
+++ b/forestry_common/farming/forestry/farming/logic/CropRubber.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogic.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogic.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicArboreal.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicArboreal.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicCereal.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicCereal.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicCocoa.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicCocoa.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicCrops.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicCrops.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicGourd.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicGourd.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicHomogenous.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicHomogenous.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicInfernal.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicInfernal.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicOrchard.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicOrchard.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicPeat.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicPeat.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicPoale.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicPoale.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicRubber.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicRubber.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicShroom.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicShroom.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicSucculent.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicSucculent.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicVegetable.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicVegetable.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmLogicWatered.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmLogicWatered.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableCocoa.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableCocoa.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableFarmCraftory.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableFarmCraftory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableGE.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableGE.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableGenericCrop.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableGenericCrop.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableGenericSapling.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableGenericSapling.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableGourd.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableGourd.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableStacked.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableStacked.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableVanillaSapling.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableVanillaSapling.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/logic/FarmableVanillaShroom.java
+++ b/forestry_common/farming/forestry/farming/logic/FarmableVanillaShroom.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/proxy/ClientProxyFarming.java
+++ b/forestry_common/farming/forestry/farming/proxy/ClientProxyFarming.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/proxy/ProxyFarming.java
+++ b/forestry_common/farming/forestry/farming/proxy/ProxyFarming.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/render/FarmItemRenderer.java
+++ b/forestry_common/farming/forestry/farming/render/FarmItemRenderer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/render/FarmRenderingHandler.java
+++ b/forestry_common/farming/forestry/farming/render/FarmRenderingHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/triggers/TriggerLowFertilizer.java
+++ b/forestry_common/farming/forestry/farming/triggers/TriggerLowFertilizer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/triggers/TriggerLowLiquid.java
+++ b/forestry_common/farming/forestry/farming/triggers/TriggerLowLiquid.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/triggers/TriggerLowSoil.java
+++ b/forestry_common/farming/forestry/farming/triggers/TriggerLowSoil.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/farming/worldgen/WorldGenBigMushroom.java
+++ b/forestry_common/farming/forestry/farming/worldgen/WorldGenBigMushroom.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/plugins/PluginFarmCraftory.java
+++ b/forestry_common/farming/forestry/plugins/PluginFarmCraftory.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/plugins/PluginFarming.java
+++ b/forestry_common/farming/forestry/plugins/PluginFarming.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/farming/forestry/plugins/PluginNatura.java
+++ b/forestry_common/farming/forestry/plugins/PluginNatura.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/BeverageEffect.java
+++ b/forestry_common/food/forestry/food/BeverageEffect.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/BeverageEffectAntidote.java
+++ b/forestry_common/food/forestry/food/BeverageEffectAntidote.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/BeverageEffectDrunk.java
+++ b/forestry_common/food/forestry/food/BeverageEffectDrunk.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/GuiHandlerFood.java
+++ b/forestry_common/food/forestry/food/GuiHandlerFood.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/gui/ContainerInfuser.java
+++ b/forestry_common/food/forestry/food/gui/ContainerInfuser.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/gui/GuiInfuser.java
+++ b/forestry_common/food/forestry/food/gui/GuiInfuser.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/items/ItemAmbrosia.java
+++ b/forestry_common/food/forestry/food/items/ItemAmbrosia.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/items/ItemBeverage.java
+++ b/forestry_common/food/forestry/food/items/ItemBeverage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/food/items/ItemInfuser.java
+++ b/forestry_common/food/forestry/food/items/ItemInfuser.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/food/forestry/plugins/PluginFood.java
+++ b/forestry_common/food/forestry/plugins/PluginFood.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/ButterflySpawner.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/ButterflySpawner.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/GuiHandlerLepidopterology.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/GuiHandlerLepidopterology.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/MatingRecipe.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/MatingRecipe.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyBase.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyBase.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyFlee.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyFlee.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyInteract.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyInteract.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyRest.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyRest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyWander.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/entities/AIButterflyWander.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/entities/EntityButterfly.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/entities/EntityButterfly.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/gadgets/TileLepidopteristChest.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/gadgets/TileLepidopteristChest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/genetics/AlleleButterflySpecies.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/genetics/AlleleButterflySpecies.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/genetics/AlleleEffectNone.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/genetics/AlleleEffectNone.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/genetics/Butterfly.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/genetics/Butterfly.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/genetics/ButterflyGenome.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/genetics/ButterflyGenome.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/genetics/ButterflyHelper.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/genetics/ButterflyHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/genetics/ButterflyTemplates.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/genetics/ButterflyTemplates.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/genetics/LepidopteristTracker.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/genetics/LepidopteristTracker.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/gui/ContainerFlutterlyzer.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/gui/ContainerFlutterlyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/gui/GuiFlutterlyzer.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/gui/GuiFlutterlyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/items/ItemButterflyGE.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/items/ItemButterflyGE.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/items/ItemFlutterlyzer.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/items/ItemFlutterlyzer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/proxy/ClientProxyLepidopterology.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/proxy/ClientProxyLepidopterology.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/proxy/ProxyLepidopterology.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/proxy/ProxyLepidopterology.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/render/ButterflyItemRenderer.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/render/ButterflyItemRenderer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/render/ModelButterfly.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/render/ModelButterfly.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/lepidopterology/render/RenderButterfly.java
+++ b/forestry_common/lepidopterology/forestry/lepidopterology/render/RenderButterfly.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/lepidopterology/forestry/plugins/PluginLepidopterology.java
+++ b/forestry_common/lepidopterology/forestry/plugins/PluginLepidopterology.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/CommandMail.java
+++ b/forestry_common/mail/forestry/mail/CommandMail.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/EnumAddressee.java
+++ b/forestry_common/mail/forestry/mail/EnumAddressee.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/EnumDeliveryState.java
+++ b/forestry_common/mail/forestry/mail/EnumDeliveryState.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/EnumStationState.java
+++ b/forestry_common/mail/forestry/mail/EnumStationState.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/GuiHandlerMail.java
+++ b/forestry_common/mail/forestry/mail/GuiHandlerMail.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/IMailContainer.java
+++ b/forestry_common/mail/forestry/mail/IMailContainer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/Letter.java
+++ b/forestry_common/mail/forestry/mail/Letter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/POBox.java
+++ b/forestry_common/mail/forestry/mail/POBox.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/POBoxInfo.java
+++ b/forestry_common/mail/forestry/mail/POBoxInfo.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/PacketHandlerMail.java
+++ b/forestry_common/mail/forestry/mail/PacketHandlerMail.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/PostOffice.java
+++ b/forestry_common/mail/forestry/mail/PostOffice.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/PostRegistry.java
+++ b/forestry_common/mail/forestry/mail/PostRegistry.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/PostalCarrier.java
+++ b/forestry_common/mail/forestry/mail/PostalCarrier.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/SaveEventHandlerMail.java
+++ b/forestry_common/mail/forestry/mail/SaveEventHandlerMail.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/TickHandlerMailClient.java
+++ b/forestry_common/mail/forestry/mail/TickHandlerMailClient.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/TradeStation.java
+++ b/forestry_common/mail/forestry/mail/TradeStation.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gadgets/MachineMailbox.java
+++ b/forestry_common/mail/forestry/mail/gadgets/MachineMailbox.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gadgets/MachinePhilatelist.java
+++ b/forestry_common/mail/forestry/mail/gadgets/MachinePhilatelist.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gadgets/MachineTrader.java
+++ b/forestry_common/mail/forestry/mail/gadgets/MachineTrader.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/ContainerCatalogue.java
+++ b/forestry_common/mail/forestry/mail/gui/ContainerCatalogue.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/ContainerLetter.java
+++ b/forestry_common/mail/forestry/mail/gui/ContainerLetter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/ContainerMailbox.java
+++ b/forestry_common/mail/forestry/mail/gui/ContainerMailbox.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/ContainerPhilatelist.java
+++ b/forestry_common/mail/forestry/mail/gui/ContainerPhilatelist.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/ContainerTradeName.java
+++ b/forestry_common/mail/forestry/mail/gui/ContainerTradeName.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/ContainerTrader.java
+++ b/forestry_common/mail/forestry/mail/gui/ContainerTrader.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/GuiCatalogue.java
+++ b/forestry_common/mail/forestry/mail/gui/GuiCatalogue.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/GuiLetter.java
+++ b/forestry_common/mail/forestry/mail/gui/GuiLetter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/GuiMailbox.java
+++ b/forestry_common/mail/forestry/mail/gui/GuiMailbox.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/GuiMailboxInfo.java
+++ b/forestry_common/mail/forestry/mail/gui/GuiMailboxInfo.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/GuiPhilatelist.java
+++ b/forestry_common/mail/forestry/mail/gui/GuiPhilatelist.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/GuiTradeName.java
+++ b/forestry_common/mail/forestry/mail/gui/GuiTradeName.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/gui/GuiTrader.java
+++ b/forestry_common/mail/forestry/mail/gui/GuiTrader.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/items/ItemCatalogue.java
+++ b/forestry_common/mail/forestry/mail/items/ItemCatalogue.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/items/ItemLetter.java
+++ b/forestry_common/mail/forestry/mail/items/ItemLetter.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/items/ItemStamps.java
+++ b/forestry_common/mail/forestry/mail/items/ItemStamps.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/network/PacketPOBoxInfo.java
+++ b/forestry_common/mail/forestry/mail/network/PacketPOBoxInfo.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/network/PacketTradeInfo.java
+++ b/forestry_common/mail/forestry/mail/network/PacketTradeInfo.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/proxy/ClientProxyMail.java
+++ b/forestry_common/mail/forestry/mail/proxy/ClientProxyMail.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/proxy/ProxyMail.java
+++ b/forestry_common/mail/forestry/mail/proxy/ProxyMail.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/triggers/TriggerBuffer.java
+++ b/forestry_common/mail/forestry/mail/triggers/TriggerBuffer.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/triggers/TriggerHasMail.java
+++ b/forestry_common/mail/forestry/mail/triggers/TriggerHasMail.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/triggers/TriggerLowInput.java
+++ b/forestry_common/mail/forestry/mail/triggers/TriggerLowInput.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/triggers/TriggerLowPaper.java
+++ b/forestry_common/mail/forestry/mail/triggers/TriggerLowPaper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/mail/triggers/TriggerLowStamps.java
+++ b/forestry_common/mail/forestry/mail/triggers/TriggerLowStamps.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/mail/forestry/plugins/PluginMail.java
+++ b/forestry_common/mail/forestry/plugins/PluginMail.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/plugins/PluginStorage.java
+++ b/forestry_common/storage/forestry/plugins/PluginStorage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/BackpackDefinition.java
+++ b/forestry_common/storage/forestry/storage/BackpackDefinition.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/BackpackHelper.java
+++ b/forestry_common/storage/forestry/storage/BackpackHelper.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/BackpackMode.java
+++ b/forestry_common/storage/forestry/storage/BackpackMode.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/GuiHandlerStorage.java
+++ b/forestry_common/storage/forestry/storage/GuiHandlerStorage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/PickupHandlerStorage.java
+++ b/forestry_common/storage/forestry/storage/PickupHandlerStorage.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/ResupplyHandler.java
+++ b/forestry_common/storage/forestry/storage/ResupplyHandler.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/gui/ContainerBackpack.java
+++ b/forestry_common/storage/forestry/storage/gui/ContainerBackpack.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/gui/ContainerNaturalistBackpack.java
+++ b/forestry_common/storage/forestry/storage/gui/ContainerNaturalistBackpack.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/gui/GuiBackpack.java
+++ b/forestry_common/storage/forestry/storage/gui/GuiBackpack.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/gui/GuiBackpackT2.java
+++ b/forestry_common/storage/forestry/storage/gui/GuiBackpackT2.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/items/ItemBackpack.java
+++ b/forestry_common/storage/forestry/storage/items/ItemBackpack.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges

--- a/forestry_common/storage/forestry/storage/items/ItemNaturalistBackpack.java
+++ b/forestry_common/storage/forestry/storage/items/ItemNaturalistBackpack.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser Public License v3
  * which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/gpl-3.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
  * 
  * Various Contributors including, but not limited to:
  * SirSengir (original work), CovertJaguar, Player, Binnie, MysteriousAges


### PR DESCRIPTION
In the boilerplate for various files, the link to the license goes to the GPL,
not LGPL.  This is likely remaining from the other stuff cleaned up in commit
027c9de, which fixed a similar mismatch.
