### PR TITLE
Avoid NPE for fringe cases

### DIFF
--- a/forestry_common/mail/forestry/mail/proxy/ClientProxyMail.java
+++ b/forestry_common/mail/forestry/mail/proxy/ClientProxyMail.java
@@ -32,7 +32,7 @@ public class ClientProxyMail extends ProxyMail {
 
 	@Override
 	public void resetMailboxInfo() {
-		if (Proxies.common.getClientInstance().thePlayer == null)
+		if (Proxies.common.getClientInstance().thePlayer == null || Proxies.common.getClientInstance().theWorld == null)
 			return;
 
 		GuiMailboxInfo.instance = new GuiMailboxInfo();


### PR DESCRIPTION
This change avoids an NPE that can occur in the rare case when thePlayer is not null, but theWorld is.
