### PR TITLE
Remove dead method from hive world gen.

### DIFF
--- a/src/main/java/forestry/apiculture/worldgen/WorldGenHive.java
+++ b/src/main/java/forestry/apiculture/worldgen/WorldGenHive.java
@@ -81,11 +81,5 @@ public abstract class WorldGenHive extends WorldGenerator {
 
 		ForestryBlock.beehives.onBlockAdded(world, x, y, z);
 		world.markBlockForUpdate(x, y, z);
-
-		postGen(world, x, y, z, meta);
-	}
-
-	protected void postGen(World world, int x, int y, int z, int meta) {
-		ForestryBlock.beehives.onBlockPlaced(world, x, y, z, 0, 0.0f, 0.0f, 0.0f, meta);
 	}
 }


### PR DESCRIPTION
BlockBeehives doesn't have an onBlockPlaced method, and the vanilla method does nothing.
Perhaps junk left over from 1.7 update.
