### PR TITLE
Removed registration of planks for wood types that don't have planks

### DIFF
--- a/src/main/java/forestry/arboriculture/WoodType.java
+++ b/src/main/java/forestry/arboriculture/WoodType.java
@@ -48,12 +48,17 @@ public enum WoodType {
 	@SideOnly(Side.CLIENT)
 	public static void registerIcons(IIconRegister register) {
 		icons = new IIcon[3][VALUES.length];
-		for (int i = 0; i < VALUES.length; i++)
-			icons[0][i] = TextureManager.getInstance().registerTex(register, "wood/planks." + VALUES[i].toString().toLowerCase(Locale.ENGLISH));
-		for (int i = 0; i < VALUES.length; i++)
-			icons[1][i] = TextureManager.getInstance().registerTex(register, "wood/bark." + VALUES[i].toString().toLowerCase(Locale.ENGLISH));
-		for (int i = 0; i < VALUES.length; i++)
-			icons[2][i] = TextureManager.getInstance().registerTex(register, "wood/heart." + VALUES[i].toString().toLowerCase(Locale.ENGLISH));
+		for (int i = 0; i < VALUES.length; i++) {
+			WoodType woodType = VALUES[i];
+			String woodName = woodType.toString().toLowerCase(Locale.ENGLISH);
+
+			if (woodType.hasPlank)
+				icons[0][i] = TextureManager.getInstance().registerTex(register, "wood/planks." + woodName);
+			else
+				icons[0][i] = null;
+			icons[1][i] = TextureManager.getInstance().registerTex(register, "wood/bark." + woodName);
+			icons[2][i] = TextureManager.getInstance().registerTex(register, "wood/heart." + woodName);
+		}
 	}
 
 	@SideOnly(Side.CLIENT)


### PR DESCRIPTION
Checks to see if the woodType.hasPlank before trying to register its planks texture.
Any future code that relies on planks should be sure to check hasPlank. For now the missing texture error is fixed and everything works. I even grew a Giganteum tree (Giant Sequoia, not Coastal), chopped its wood, and attempted to make planks. It doesn't make planks (as expected), and no NPE.
Fixes #113
