### PR TITLE
Added check for bad centrifuge recipes that crash the game.

### DIFF
--- a/src/main/java/forestry/factory/gadgets/MachineCentrifuge.java
+++ b/src/main/java/forestry/factory/gadgets/MachineCentrifuge.java
@@ -58,6 +58,11 @@ public class MachineCentrifuge extends TilePowered implements ISidedInventory, I
 			this.timePerItem = timePerItem;
 			this.resource = resource;
 			this.products = products;
+
+			for (ItemStack item : products.keySet()) {
+				if (item == null)
+					throw new IllegalArgumentException("Tried to register a null product of " + resource);
+			}
 		}
 
 		public boolean matches(ItemStack res) {


### PR DESCRIPTION
Helps diagnose issues like #103.
Bad recipes coming in through the API will now crash on startup instead of hanging around causing difficult-to-track issues.
