### PR TITLE
Set toolClass of ItemWrench to "wrench"

### DIFF
--- a/src/main/java/forestry/core/items/ItemWrench.java
+++ b/src/main/java/forestry/core/items/ItemWrench.java
@@ -23,6 +23,7 @@ public class ItemWrench extends ItemForestry implements IToolWrench {
 
 	public ItemWrench() {
 		super();
+		setHarvestLevel("wrench", 0);
 	}
 
 	@Override


### PR DESCRIPTION
Allows other mods to use the wrench (for things other then rotation) without needing to know the itemstack.
