### PR TITLE
Make backpack config much more forgiving.

### DIFF
--- a/cla-signatures.txt
+++ b/cla-signatures.txt
@@ -1,2 +1,3 @@
 Account;Email;Date;
 samtrion;samtrion@gmail.com;2015-01-18
+GenuineSounds;GenuineSoundsLtd@gmail.com;2015-02-26

--- a/src/main/java/forestry/plugins/PluginStorage.java
+++ b/src/main/java/forestry/plugins/PluginStorage.java
@@ -567,6 +567,7 @@ public class PluginStorage extends ForestryPlugin implements IOreDictionaryHandl
 		String[] parts = list.split("(\\s*;\\s*)+");
 
 		for (String part : parts) {
+			part = part.trim();
 			if (part.isEmpty()) {
 				continue;
 			}

--- a/src/main/java/forestry/plugins/PluginStorage.java
+++ b/src/main/java/forestry/plugins/PluginStorage.java
@@ -564,14 +564,14 @@ public class PluginStorage extends ForestryPlugin implements IOreDictionaryHandl
 	}
 
 	private static void parseBackpackItems(String backpackIdent, String list, IBackpackDefinition target) {
-		String[] parts = list.split("[;]+");
+		String[] parts = list.split("(\\s*;\\s*)+");
 
 		for (String part : parts) {
 			if (part.isEmpty()) {
 				continue;
 			}
 
-			String[] ident = part.split("[:]+");
+			String[] ident = part.split(":+");
 
 			if (ident.length != 2 && ident.length != 3) {
 				Proxies.log.warning("Failed to add block/item of (" + part + ") to " + backpackIdent + " since it isn't formatted properly. Suitable are <name>, <name>:<meta> or <name>:*, e.g. IC2:blockWall:*.");


### PR DESCRIPTION
Make backpack config much more forgiving of white-space characters in between definitions. Also it will skip entire sections that are empty.

Here are the split pattern results.
https://dl.dropboxusercontent.com/u/79514/Screenshots/Features/Screenshot%202015-02-26%2001.46.29.png