### PR TITLE
Change fence recipes to match vanilla's style

### DIFF
--- a/cla-signatures.txt
+++ b/cla-signatures.txt
@@ -2,3 +2,4 @@ Account;Email;Date;
 samtrion;samtrion@gmail.com;2015-01-18
 GenuineSounds;GenuineSoundsLtd@gmail.com;2015-02-26
 airbreather;airbreather@linux.com;2015-04-10
+ganymedes01;foka_12@hotmail.com;2015-05-27

--- a/src/main/java/forestry/plugins/PluginArboriculture.java
+++ b/src/main/java/forestry/plugins/PluginArboriculture.java
@@ -538,9 +538,13 @@ public class PluginArboriculture extends ForestryPlugin {
 		for (WoodType woodType : WoodType.values()) {
 			int i = woodType.ordinal();
 			if (i < 16) {
+				// TODO remove first recipe on 1.8
 				Proxies.common.addRecipe(ForestryBlock.fences1.getItemStack(4, i % 16), "###", "# #", '#', ForestryBlock.planks1.getItemStack(1, i % 16));
+				Proxies.common.addRecipe(ForestryBlock.fences1.getItemStack(3, i % 16), "#X#", "#X#", '#', ForestryBlock.planks1.getItemStack(1, i % 16), 'X', "stickWood");
 			} else if (i < 32) {
+				// TODO remove first recipe on 1.8
 				Proxies.common.addRecipe(ForestryBlock.fences2.getItemStack(4, i % 16), "###", "# #", '#', ForestryBlock.planks2.getItemStack(1, i % 16));
+				Proxies.common.addRecipe(ForestryBlock.fences2.getItemStack(3, i % 16), "#X#", "#X#", '#', ForestryBlock.planks2.getItemStack(1, i % 16), 'X', "stickWood");
 			} else {
 				throw new RuntimeException("Wood type has no fences defined");
 			}


### PR DESCRIPTION
I know forestry is not in 1.8 yet, but why not use it's recipe pattern for fences?

As seen here: http://minecraft.gamepedia.com/Fence
Fences in 1.8 are crafted with an specific type of wood and sticks in the middle, yielding 3 fences per recipe.