### PR TITLE
Enable lighting when rendering TESRs

### DIFF
--- a/src/main/java/forestry/apiculture/render/ModelAnalyzer.java
+++ b/src/main/java/forestry/apiculture/render/ModelAnalyzer.java
@@ -59,7 +59,6 @@ public class ModelAnalyzer extends ModelBase {
 	public void render(ForgeDirection orientation, float posX, float posY, float posZ) {
 
 		GL11.glPushMatrix();
-		GL11.glDisable(GL11.GL_LIGHTING);
 
 		GL11.glTranslatef(posX, posY, posZ);
 		float[] angle = {0, 0, 0};
@@ -108,7 +107,6 @@ public class ModelAnalyzer extends ModelBase {
 		Proxies.common.bindTexture(textures[2]);
 		tower2.render(factor);
 
-		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glPopMatrix();
 
 	}

--- a/src/main/java/forestry/core/render/RenderEscritoire.java
+++ b/src/main/java/forestry/core/render/RenderEscritoire.java
@@ -65,7 +65,6 @@ public class RenderEscritoire extends TileEntitySpecialRenderer implements IBloc
 		float factor = (float) (1.0 / 16.0);
 
 		GL11.glPushMatrix();
-		GL11.glDisable(GL11.GL_LIGHTING);
 		GL11.glTranslatef((float) x + 0.5f, (float) y + 0.875f, (float) z + 0.5f);
 
 		float[] angle = {(float) Math.PI, 0, 0};
@@ -91,7 +90,6 @@ public class RenderEscritoire extends TileEntitySpecialRenderer implements IBloc
 		Proxies.common.bindTexture(texture);
 		modelEscritoire.render(null, angle[0], angle[1], angle[2], 0f, 0f, factor);
 
-		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glPopMatrix();
 
 		/*

--- a/src/main/java/forestry/core/render/RenderMill.java
+++ b/src/main/java/forestry/core/render/RenderMill.java
@@ -107,7 +107,6 @@ public class RenderMill extends TileEntitySpecialRenderer implements IBlockRende
 	private void render(float progress, int charge, ForgeDirection orientation, double x, double y, double z) {
 
 		GL11.glPushMatrix();
-		GL11.glDisable(2896 /* GL_LIGHTING */);
 
 		GL11.glTranslatef((float) x, (float) y, (float) z);
 
@@ -196,7 +195,6 @@ public class RenderMill extends TileEntitySpecialRenderer implements IBlockRende
 		GL11.glTranslatef(-translate[0] * tfactor, translate[1] * tfactor, -translate[2] * tfactor);
 		blade2.render(factor);
 
-		GL11.glEnable(2896 /* GL_LIGHTING */);
 		GL11.glPopMatrix();
 
 	}


### PR DESCRIPTION
Blocks look a lot better if you do it.

Before:
<img width="759" alt="screen shot 2015-08-19 at 17 46 36" src="https://cloud.githubusercontent.com/assets/5294529/9362749/48b2cb62-469a-11e5-9ef8-38e4f9487da4.png">

After:
<img width="761" alt="screen shot 2015-08-19 at 17 38 52" src="https://cloud.githubusercontent.com/assets/5294529/9362715/13ef4d88-469a-11e5-99b8-c4424101dc04.png">
