### PR TITLE
Fix rainmaker crash

### DIFF
--- a/src/main/java/forestry/factory/gadgets/MillRainmaker.java
+++ b/src/main/java/forestry/factory/gadgets/MillRainmaker.java
@@ -139,7 +139,7 @@ public class MillRainmaker extends Mill {
 		public void setInventorySlotContents(int slotIndex, ItemStack itemStack) {
 			if (slotIndex == SLOT_SUBSTRATE) {
 				RainSubstrate substrate = FuelManager.rainSubstrate.get(itemStack);
-				if (substrate.item.isItemEqual(itemStack)) {
+				if (substrate != null && substrate.item.isItemEqual(itemStack)) {
 					tile.addCharge(substrate);
 					tile.sendNetworkUpdate();
 				}


### PR DESCRIPTION
Bumped into this by accident.
Breaking the rainmaker causes a crash with a null pointer exception due to `FuelManager.rainSubstrate.get(null)` returning null
