### PR TITLE
Fixes to OreDictionary support in squeezer recipes 

### DIFF
--- a/src/main/java/forestry/factory/gadgets/MachineSqueezer.java
+++ b/src/main/java/forestry/factory/gadgets/MachineSqueezer.java
@@ -386,6 +386,14 @@ public class MachineSqueezer extends TilePowered implements ISocketable, ISidedI
 		}
 
 		public static ISqueezerRecipe findMatchingRecipe(ItemStack[] items) {
+			// First try to match a specific recipe (without OD)
+			for (ISqueezerRecipe recipe : recipes) {
+				if (StackUtils.containsSets(recipe.getResources(), items, false, false) > 0) {
+					return recipe;
+				}
+			}
+
+			// If that fails - try again with oredict support enabled
 			for (ISqueezerRecipe recipe : recipes) {
 				if (StackUtils.containsSets(recipe.getResources(), items, true, false) > 0) {
 					return recipe;
@@ -400,7 +408,7 @@ public class MachineSqueezer extends TilePowered implements ISocketable, ISidedI
 				return true;
 			}
 			for (ItemStack recipeInput : recipeInputs) {
-				if (StackUtils.isCraftingEquivalent(recipeInput, itemStack)) {
+				if (StackUtils.isCraftingEquivalent(recipeInput, itemStack, true, false)) {
 					return true;
 				}
 			}

--- a/src/main/java/forestry/factory/recipes/nei/NEIHandlerSqueezer.java
+++ b/src/main/java/forestry/factory/recipes/nei/NEIHandlerSqueezer.java
@@ -157,13 +157,12 @@ public class NEIHandlerSqueezer extends RecipeHandlerBase {
 
 	@Override
 	public void loadUsageRecipes(ItemStack ingred) {
-		for (ISqueezerRecipe recipe : MachineSqueezer.RecipeManager.recipes) {
+		ISqueezerRecipe recipe = MachineSqueezer.RecipeManager.findMatchingRecipe(new ItemStack[]{ingred});
+		if (recipe != null) {
 			CachedSqueezerRecipe crecipe = new CachedSqueezerRecipe(recipe);
-			if (crecipe.inputs != null && crecipe.contains(crecipe.inputs, ingred)) {
-				crecipe.generatePermutations();
-				crecipe.setIngredientPermutation(crecipe.inputs, ingred);
-				this.arecipes.add(crecipe);
-			}
+			// Override recipe to show the right input in case it's OD
+			crecipe.setIngredients(new ItemStack[]{ingred});
+			this.arecipes.add(crecipe);
 		}
 	}
 


### PR DESCRIPTION
Squeezer recipes in forestry at some point switched to use oredict. I'm currently registering all my custom honey drops as dropHoney which makes any custom squeezer recipes for them not work.

Moreover the Squeezer doesn't actually checks for OD matches when accepting items, making the check in recipes useless.

After some discussion in #forestry-dev the proposed solution (by vexatos) was to scan the registry twice - first without checking OD and if that fails, again with OD check enabled.

This patch changes the following:
- Implements dual registry scan when looking for recipe, first without OD then if that fails with OD
- Fixes item input to accept items that match recipes with OD
- Fixes the NEI handler to show those recipes correctly

I have tested it with Forestry recipes and custom honeydrops from gendustry and it seems i didn't break anything :P
