### PR TITLE
Fixes for 3.6.x - BeekeepingLogic overwriting queens with old data + OreDict use in Squeezer recipes

### DIFF
--- a/src/main/java/forestry/apiculture/BeekeepingLogic.java
+++ b/src/main/java/forestry/apiculture/BeekeepingLogic.java
@@ -46,6 +46,7 @@ public class BeekeepingLogic implements IBeekeepingLogic {
 	private int breedingTime;
 	private int queenWorkCycleThrottle;
 	private IEffectData effectData[] = new IEffectData[2];
+	private ItemStack queenStack;
 	private IBee queen;
 	private IIndividual pollen;
 	private int attemptedPollinations = 0;
@@ -308,6 +309,11 @@ public class BeekeepingLogic implements IBeekeepingLogic {
 		EnumErrorCode housingErrorState = null;
 
 		ItemStack queenStack = housing.getQueen();
+
+		if (!ItemStack.areItemStacksEqual(this.queenStack, queenStack)) {
+			this.queen = BeeManager.beeRoot.getMember(queenStack);
+			this.queenStack = queenStack;
+		}
 
 		if (queenStack == null || !ForestryItem.beeQueenGE.isItemEqual(queenStack)) {
 			housingErrorState = EnumErrorCode.NOQUEEN;

--- a/src/main/java/forestry/factory/gadgets/MachineSqueezer.java
+++ b/src/main/java/forestry/factory/gadgets/MachineSqueezer.java
@@ -76,8 +76,8 @@ public class MachineSqueezer extends TilePowered implements ISidedInventory, ILi
 			this.chance = chance;
 		}
 
-		public boolean matches(ItemStack[] res) {
-			return StackUtils.containsSets(resources, res, true, true) > 0;
+		public boolean matches(ItemStack[] res, boolean oreDict) {
+			return StackUtils.containsSets(resources, res, oreDict, true) > 0;
 		}
 	}
 
@@ -104,8 +104,16 @@ public class MachineSqueezer extends TilePowered implements ISidedInventory, ILi
 		}
 
 		public static Recipe findMatchingRecipe(ItemStack[] items) {
+			// First try to match a specific recipe (without OD)
 			for (Recipe recipe : recipes) {
-				if (recipe.matches(items)) {
+				if (recipe.matches(items, false)) {
+					return recipe;
+				}
+			}
+
+			// If that fails - try again with oredict support enabled
+			for (Recipe recipe : recipes) {
+				if (recipe.matches(items, true)) {
 					return recipe;
 				}
 			}
@@ -118,7 +126,7 @@ public class MachineSqueezer extends TilePowered implements ISidedInventory, ILi
 				return true;
 			}
 			for (ItemStack recipeInput : recipeInputs) {
-				if (StackUtils.isCraftingEquivalent(recipeInput, itemStack)) {
+				if (StackUtils.isCraftingEquivalent(recipeInput, itemStack, true, true)) {
 					return true;
 				}
 			}


### PR DESCRIPTION
- Fixed #817 by adding the check for 4.0 for ItemStack changes
- Adapted the fix in #815 to 3.6.x
