### PR TITLE
Enable lighting when rendering TESRs (part 2)

### DIFF
--- a/src/main/java/forestry/core/render/RenderMachine.java
+++ b/src/main/java/forestry/core/render/RenderMachine.java
@@ -115,7 +115,6 @@ public class RenderMachine extends TileEntitySpecialRenderer implements IBlockRe
 		EnumTankLevel melangeLevel = EnumTankLevel.values()[melangeLevelInt];
 
 		GL11.glPushMatrix();
-		GL11.glDisable(GL11.GL_LIGHTING);
 		GL11.glTranslatef((float) x, (float) y, (float) z);
 
 		float[] angle = {0, 0, 0};
@@ -215,7 +214,6 @@ public class RenderMachine extends TileEntitySpecialRenderer implements IBlockRe
 		Proxies.common.bindTexture(texture);
 		productTank.render(factor);
 
-		GL11.glEnable(GL11.GL_LIGHTING);
 		GL11.glPopMatrix();
 	}
 }


### PR DESCRIPTION
I missed this one when doing PR #800. Sorry about that.
Before:
<img width="410" alt="screen shot 2015-09-11 at 15 40 14" src="https://cloud.githubusercontent.com/assets/5294529/9818860/84f2838c-58a2-11e5-9357-35432f95c9e5.png">

After:
<img width="325" alt="screen shot 2015-09-11 at 15 41 22" src="https://cloud.githubusercontent.com/assets/5294529/9818857/817c0c1e-58a2-11e5-955a-ebf2e27ebde3.png">
