### PR TITLE
FlowerRegistry and AgriCraft compatibility update

### DIFF
--- a/cla-signatures.txt
+++ b/cla-signatures.txt
@@ -3,3 +3,4 @@ samtrion;samtrion@gmail.com;2015-01-18
 GenuineSounds;GenuineSoundsLtd@gmail.com;2015-02-26
 airbreather;airbreather@linux.com;2015-04-10
 ganymedes01;foka_12@hotmail.com;2015-05-27
+infinityraider;theoneandonlyraider@gmail;com;2015-10-03

--- a/src/main/java/forestry/apiculture/flowers/FlowerRegistry.java
+++ b/src/main/java/forestry/apiculture/flowers/FlowerRegistry.java
@@ -34,6 +34,7 @@ import net.minecraft.tileentity.TileEntityFlowerPot;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.World;
 
+import net.minecraftforge.common.IPlantable;
 import net.minecraftforge.oredict.OreDictionary;
 
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -190,15 +191,21 @@ public final class FlowerRegistry implements IFlowerRegistry {
 			meta = world.getBlockMetadata(x, y, z);
 		}
 
-		if (PluginManager.Module.AGRICRAFT.isEnabled() && (flowerType.equals(FlowerManager.FlowerTypeWheat) || flowerType.equals(FlowerManager.FlowerTypeNether))) {
+		if (PluginManager.Module.AGRICRAFT.isEnabled()) {
 			Block cropBlock = GameRegistry.findBlock("AgriCraft", "crops");
 			if (block == cropBlock) {
-				ArrayList<ItemStack> drops = block.getDrops(world, x, y, z, 7, 0);
-				if (drops.get(1).getItem() == Items.wheat_seeds && flowerType.equals(FlowerManager.FlowerTypeWheat)) {
-					return true;
-				}
-				if (drops.get(1).getItem() == Items.nether_wart && flowerType.equals(FlowerManager.FlowerTypeNether)) {
-					return true;
+				if(block instanceof IPlantable) {
+					//For agricraft versions which implement IPlantable in the BlockCrop class
+					block = ((IPlantable) block).getPlant(world, x, y, z);
+				} else {
+					//For earlyer versions of AgriCraft
+					ArrayList<ItemStack> drops = block.getDrops(world, x, y, z, 7, 0);
+					if (drops.get(1).getItem() == Items.wheat_seeds && flowerType.equals(FlowerManager.FlowerTypeWheat)) {
+						return true;
+					}
+					if (drops.get(1).getItem() == Items.nether_wart && flowerType.equals(FlowerManager.FlowerTypeNether)) {
+						return true;
+					}
 				}
 			}
 		}

--- a/src/main/java/forestry/apiculture/flowers/FlowerRegistry.java
+++ b/src/main/java/forestry/apiculture/flowers/FlowerRegistry.java
@@ -198,7 +198,7 @@ public final class FlowerRegistry implements IFlowerRegistry {
 					//For agricraft versions which implement IPlantable in the BlockCrop class
 					block = ((IPlantable) block).getPlant(world, x, y, z);
 				} else {
-					//For earlyer versions of AgriCraft
+					//For earlier versions of AgriCraft
 					ArrayList<ItemStack> drops = block.getDrops(world, x, y, z, 7, 0);
 					if (drops.get(1).getItem() == Items.wheat_seeds && flowerType.equals(FlowerManager.FlowerTypeWheat)) {
 						return true;


### PR DESCRIPTION
I've correctly implemented the IPlantable interface into my BlockCrop class which allows to get the Block object corresponding with the planted seed on crop sticks as such: https://github.com/InfinityRaider/AgriCraft/blob/master/src/main/java/com/InfinityRaider/AgriCraft/blocks/BlockCrop.java#L723-L739

This allows for compatibility with the flower registry, regardless of which seed is planted.
I've kept the cases you guys added in for compatibility with older versions of AgriCraft.
