### PR TITLE
Workaround to allow other mods to get plank icons without position

### DIFF
--- a/src/main/java/forestry/arboriculture/blocks/BlockPlanks.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockPlanks.java
@@ -45,7 +45,10 @@ public class BlockPlanks extends BlockWood {
 	@SideOnly(Side.CLIENT)
 	@Override
 	public IIcon getIcon(int side, int meta) {
-		return IconProviderWood.getPlankIcon(EnumWoodType.LARCH);
+		EnumWoodType woodType = EnumWoodType.LARCH;
+		if (meta > 0 && meta < EnumWoodType.VALUES.length)
+			woodType = EnumWoodType.VALUES[meta];
+		return IconProviderWood.getPlankIcon(woodType);
 	}
 
 	@Override


### PR DESCRIPTION
I have a mod called [WoodStuff](http://minecraft.curseforge.com/projects/wood-stuff) that adds several wood blocks (like bookshelves, chests, buttons, etc) made out of other mod's planks.
It assumes that planks have their icons determined using solely metadata (I thought it would be okay to do it this way because so far I hadn't found any mod that used TileEntities).

This simple workaround would be enough to fix Forestry's support for WoodStuff, so I hope that's okay.
