### PR TITLE
Add IC2 crops support to multifarms (uses orchard farm logic)

### DIFF
--- a/src/main/java/forestry/farming/logic/CropBasicIC2Crop.java
+++ b/src/main/java/forestry/farming/logic/CropBasicIC2Crop.java
@@ -1,0 +1,28 @@
+package forestry.farming.logic;
+
+import forestry.core.utils.vect.Vect;
+import forestry.plugins.compat.PluginIC2;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+import java.util.Collection;
+
+public class CropBasicIC2Crop extends Crop {
+	private final TileEntity tileEntity;
+
+	public CropBasicIC2Crop(World world, TileEntity tileEntity, Vect position) {
+		super(world, position);
+		this.tileEntity = tileEntity;
+	}
+
+	@Override
+	protected boolean isCrop(Vect pos) {
+		return PluginIC2.instance.canHarvestCrop(this.tileEntity);
+	}
+
+	@Override
+	protected Collection<ItemStack> harvestBlock(Vect pos) {
+		return PluginIC2.instance.getCropDrops(this.tileEntity);
+	}
+}

--- a/src/main/java/forestry/farming/logic/FarmableBasicIC2Crop.java
+++ b/src/main/java/forestry/farming/logic/FarmableBasicIC2Crop.java
@@ -1,0 +1,52 @@
+package forestry.farming.logic;
+
+import forestry.api.farming.ICrop;
+import forestry.api.farming.IFarmable;
+import forestry.core.utils.vect.Vect;
+import forestry.plugins.compat.PluginIC2;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+public class FarmableBasicIC2Crop implements IFarmable {
+	@Override
+	public boolean isSaplingAt(World world, int x, int y, int z) {
+		TileEntity crop = world.getTileEntity(x, y, z);
+		if(PluginIC2.instance.isIC2Crop(crop)) {
+			PluginIC2.instance.babysitCrop(crop);
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public ICrop getCropAt(World world, int x, int y, int z) {
+		TileEntity crop = world.getTileEntity(x, y, z);
+		if (crop == null) {
+			return null;
+		}
+		if (!PluginIC2.instance.isIC2Crop(crop)) {
+			return null;
+		}
+		if (!PluginIC2.instance.canHarvestCrop(crop)) {
+			return null;
+		}
+		return new CropBasicIC2Crop(world, crop, new Vect(x, y, z));
+	}
+
+	@Override
+	public boolean isGermling(ItemStack itemstack) {
+		return false;
+	}
+
+	@Override
+	public boolean isWindfall(ItemStack itemstack) {
+		return false;
+	}
+
+	@Override
+	public boolean plantSaplingAt(EntityPlayer player, ItemStack germling, World world, int x, int y, int z) {
+		return false;
+	}
+}


### PR DESCRIPTION
I've added ic2 crop support to farms. I might work on an optimal solution in the future that includes a new farm logic to turn the farm into the crop harvester + crop-matron combo but for now this works prefectly.
