### PR TITLE
Allow overriding climate when checking for mutations

### DIFF
--- a/src/main/java/forestry/api/apiculture/IBeeHousing.java
+++ b/src/main/java/forestry/api/apiculture/IBeeHousing.java
@@ -7,6 +7,7 @@ package forestry.api.apiculture;
 
 import javax.annotation.Nonnull;
 
+import forestry.api.core.IClimateProvider;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -18,7 +19,7 @@ import forestry.api.core.EnumTemperature;
 import forestry.api.core.IErrorLogicSource;
 import forestry.api.genetics.IHousing;
 
-public interface IBeeHousing extends IHousing, IErrorLogicSource {
+public interface IBeeHousing extends IHousing, IErrorLogicSource, IClimateProvider {
 
 	/**
 	 * Used by BeeManager.beeRoot.createBeeHousingModifier(IBeeHousing housing)
@@ -39,18 +40,12 @@ public interface IBeeHousing extends IHousing, IErrorLogicSource {
 
 	IBeekeepingLogic getBeekeepingLogic();
 
-	EnumTemperature getTemperature();
-
-	EnumHumidity getHumidity();
-
 	int getBlockLightValue();
 
 	boolean canBlockSeeTheSky();
 
 	/** Must not be named "getWorld" to avoid SpecialSource issue https://github.com/md-5/SpecialSource/issues/12 */
 	World getWorldObj();
-
-	Biome getBiome();
 
 	GameProfile getOwner();
 

--- a/src/main/java/forestry/api/apiculture/package-info.java
+++ b/src/main/java/forestry/api/apiculture/package-info.java
@@ -3,7 +3,7 @@
  *
  * This work (the API) is licensed under the "MIT" License, see LICENSE.txt for details.
  ******************************************************************************/
-@API(apiVersion = "4.8.0", owner = "ForestryAPI|core", provides = "ForestryAPI|apiculture")
+@API(apiVersion = "5.0.0", owner = "ForestryAPI|core", provides = "ForestryAPI|apiculture")
 package forestry.api.apiculture;
 
 import net.minecraftforge.fml.common.API;

--- a/src/main/java/forestry/api/core/IClimateManager.java
+++ b/src/main/java/forestry/api/core/IClimateManager.java
@@ -13,5 +13,7 @@ public interface IClimateManager {
 	float getTemperature(World world, BlockPos pos);
 	
 	float getHumidity(World world, BlockPos pos);
-	
+
+	IClimateProvider getDefaultClimate(World world, BlockPos pos);
+
 }

--- a/src/main/java/forestry/api/core/IClimateProvider.java
+++ b/src/main/java/forestry/api/core/IClimateProvider.java
@@ -1,0 +1,11 @@
+package forestry.api.core;
+
+import net.minecraft.world.biome.Biome;
+
+public interface IClimateProvider {
+    Biome getBiome();
+
+    EnumTemperature getTemperature();
+
+    EnumHumidity getHumidity();
+}

--- a/src/main/java/forestry/api/genetics/IMutationCondition.java
+++ b/src/main/java/forestry/api/genetics/IMutationCondition.java
@@ -5,6 +5,7 @@
  ******************************************************************************/
 package forestry.api.genetics;
 
+import forestry.api.core.IClimateProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -15,7 +16,7 @@ public interface IMutationCondition {
 	 * Most will return 1 if the condition is met and 0 otherwise,
 	 * but the float offers flexibility for more advanced conditions.
 	 */
-	float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1);
+	float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1, IClimateProvider climate);
 
 	/**
 	 * A localized description of the mutation condition. (i.e. "A temperature of HOT is required.")

--- a/src/main/java/forestry/api/lepidopterology/IButterflyNursery.java
+++ b/src/main/java/forestry/api/lepidopterology/IButterflyNursery.java
@@ -5,10 +5,11 @@
  ******************************************************************************/
 package forestry.api.lepidopterology;
 
+import forestry.api.core.IClimateProvider;
 import forestry.api.genetics.IHousing;
 import forestry.api.genetics.IIndividual;
 
-public interface IButterflyNursery extends IHousing {
+public interface IButterflyNursery extends IHousing, IClimateProvider {
 	
 	IButterfly getCaterpillar();
 	

--- a/src/main/java/forestry/apiculture/genetics/BeeMutation.java
+++ b/src/main/java/forestry/apiculture/genetics/BeeMutation.java
@@ -45,7 +45,7 @@ public class BeeMutation extends Mutation implements IBeeMutation, IBeeMutationB
 		World world = housing.getWorldObj();
 		BlockPos housingPos = housing.getCoordinates();
 
-		float processedChance = super.getChance(world, housingPos, allele0, allele1, genome0, genome1);
+		float processedChance = super.getChance(world, housingPos, allele0, allele1, genome0, genome1, housing);
 		if (processedChance <= 0) {
 			return 0;
 		}

--- a/src/main/java/forestry/arboriculture/genetics/TreeMutation.java
+++ b/src/main/java/forestry/arboriculture/genetics/TreeMutation.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package forestry.arboriculture.genetics;
 
+import forestry.api.core.ForestryAPI;
+import forestry.core.DefaultClimateProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -40,7 +42,7 @@ public class TreeMutation extends Mutation implements ITreeMutation, ITreeMutati
 
 	@Override
 	public float getChance(World world, BlockPos pos, IAlleleTreeSpecies allele0, IAlleleTreeSpecies allele1, ITreeGenome genome0, ITreeGenome genome1) {
-		float processedChance = super.getChance(world, pos, allele0, allele1, genome0, genome1);
+		float processedChance = super.getChance(world, pos, allele0, allele1, genome0, genome1, ForestryAPI.climateManager.getDefaultClimate(world, pos));
 		if (processedChance <= 0) {
 			return 0;
 		}

--- a/src/main/java/forestry/arboriculture/tiles/TileLeaves.java
+++ b/src/main/java/forestry/arboriculture/tiles/TileLeaves.java
@@ -507,7 +507,7 @@ public class TileLeaves extends TileTreeContainer implements IPollinatable, IFru
 
 	@Override
 	public EnumTemperature getTemperature() {
-		return EnumTemperature.getFromValue(ForestryAPI.climateManager.getTemperature(worldObj, pos));
+		return EnumTemperature.getFromBiome(worldObj.getBiome(pos), worldObj, pos);
 	}
 
 	@Override

--- a/src/main/java/forestry/arboriculture/tiles/TileLeaves.java
+++ b/src/main/java/forestry/arboriculture/tiles/TileLeaves.java
@@ -27,6 +27,9 @@ import forestry.api.arboriculture.ITree;
 import forestry.api.arboriculture.ITreeGenome;
 import forestry.api.arboriculture.ITreekeepingMode;
 import forestry.api.arboriculture.TreeManager;
+import forestry.api.core.EnumHumidity;
+import forestry.api.core.EnumTemperature;
+import forestry.api.core.ForestryAPI;
 import forestry.api.genetics.AlleleManager;
 import forestry.api.genetics.IAllele;
 import forestry.api.genetics.IEffectData;
@@ -55,6 +58,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.EnumPlantType;
 
 public class TileLeaves extends TileTreeContainer implements IPollinatable, IFruitBearer, IButterflyNursery, IRipeningPacketReceiver {
@@ -494,5 +498,20 @@ public class TileLeaves extends TileTreeContainer implements IPollinatable, IFru
 	public boolean canNurse(IButterfly butterfly) {
 		ITree tree = getTree();
 		return !isDestroyed(tree, damage) && caterpillar == null;
+	}
+
+	@Override
+	public Biome getBiome() {
+		return worldObj.getBiome(pos);
+	}
+
+	@Override
+	public EnumTemperature getTemperature() {
+		return EnumTemperature.getFromValue(ForestryAPI.climateManager.getTemperature(worldObj, pos));
+	}
+
+	@Override
+	public EnumHumidity getHumidity() {
+		return EnumHumidity.getFromValue(ForestryAPI.climateManager.getHumidity(worldObj, pos));
 	}
 }

--- a/src/main/java/forestry/core/ClimateManager.java
+++ b/src/main/java/forestry/core/ClimateManager.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.core;
 
+import forestry.api.core.IClimateProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -42,4 +43,8 @@ public class ClimateManager implements IClimateManager{
 		return biome.getRainfall();
 	}
 
+	@Override
+	public IClimateProvider getDefaultClimate(World world, BlockPos pos) {
+		return new DefaultClimateProvider(world, pos);
+	}
 }

--- a/src/main/java/forestry/core/DefaultClimateProvider.java
+++ b/src/main/java/forestry/core/DefaultClimateProvider.java
@@ -1,0 +1,34 @@
+package forestry.core;
+
+import forestry.api.core.EnumHumidity;
+import forestry.api.core.EnumTemperature;
+import forestry.api.core.ForestryAPI;
+import forestry.api.core.IClimateProvider;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+
+public class DefaultClimateProvider implements IClimateProvider {
+    private World world;
+    private BlockPos pos;
+
+    public DefaultClimateProvider(World world, BlockPos pos) {
+        this.world = world;
+        this.pos = pos;
+    }
+
+    @Override
+    public Biome getBiome() {
+        return world.getBiome(pos);
+    }
+
+    @Override
+    public EnumTemperature getTemperature() {
+        return EnumTemperature.getFromBiome(world.getBiome(pos), world, pos);
+    }
+
+    @Override
+    public EnumHumidity getHumidity() {
+        return EnumHumidity.getFromValue(ForestryAPI.climateManager.getHumidity(world, pos));
+    }
+}

--- a/src/main/java/forestry/core/genetics/mutations/Mutation.java
+++ b/src/main/java/forestry/core/genetics/mutations/Mutation.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import forestry.api.core.EnumHumidity;
 import forestry.api.core.EnumTemperature;
+import forestry.api.core.IClimateProvider;
 import forestry.api.genetics.IAllele;
 import forestry.api.genetics.IAlleleSpecies;
 import forestry.api.genetics.IGenome;
@@ -124,10 +125,10 @@ public abstract class Mutation implements IMutation, IMutationBuilder {
 		return this;
 	}
 
-	protected float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
+	protected float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1, IClimateProvider climate) {
 		float mutationChance = chance;
 		for (IMutationCondition mutationCondition : mutationConditions) {
-			mutationChance *= mutationCondition.getChance(world, pos, allele0, allele1, genome0, genome1);
+			mutationChance *= mutationCondition.getChance(world, pos, allele0, allele1, genome0, genome1, climate);
 			if (mutationChance == 0) {
 				return 0;
 			}

--- a/src/main/java/forestry/core/genetics/mutations/MutationConditionBiome.java
+++ b/src/main/java/forestry/core/genetics/mutations/MutationConditionBiome.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import forestry.api.core.IClimateProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -34,8 +35,8 @@ public class MutationConditionBiome implements IMutationCondition {
 	}
 
 	@Override
-	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
-		Biome biome = world.getBiome(pos);
+	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1, IClimateProvider climate) {
+		Biome biome = climate.getBiome();
 		for (BiomeDictionary.Type type : validBiomeTypes) {
 			if (BiomeDictionary.isBiomeOfType(biome, type)) {
 				return 1;

--- a/src/main/java/forestry/core/genetics/mutations/MutationConditionDaytime.java
+++ b/src/main/java/forestry/core/genetics/mutations/MutationConditionDaytime.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.core.genetics.mutations;
 
+import forestry.api.core.IClimateProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -27,7 +28,7 @@ public class MutationConditionDaytime implements IMutationCondition {
 	}
 
 	@Override
-	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
+	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1, IClimateProvider climate) {
 		if (world.isDaytime() == daytime) {
 			return 1;
 		}

--- a/src/main/java/forestry/core/genetics/mutations/MutationConditionHumidity.java
+++ b/src/main/java/forestry/core/genetics/mutations/MutationConditionHumidity.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.core.genetics.mutations;
 
+import forestry.api.core.IClimateProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -31,8 +32,8 @@ public class MutationConditionHumidity implements IMutationCondition {
 	}
 
 	@Override
-	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
-		EnumHumidity biomeHumidity = EnumHumidity.getFromValue(ForestryAPI.climateManager.getHumidity(world, pos));
+	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1, IClimateProvider climate) {
+		EnumHumidity biomeHumidity = climate.getHumidity();
 
 		if (biomeHumidity.ordinal() < minHumidity.ordinal() || biomeHumidity.ordinal() > maxHumidity.ordinal()) {
 			return 0;

--- a/src/main/java/forestry/core/genetics/mutations/MutationConditionRequiresResource.java
+++ b/src/main/java/forestry/core/genetics/mutations/MutationConditionRequiresResource.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import forestry.api.apiculture.IBeeHousing;
+import forestry.api.core.IClimateProvider;
 import forestry.api.genetics.IAllele;
 import forestry.api.genetics.IGenome;
 import forestry.api.genetics.IMutationCondition;
@@ -54,7 +55,7 @@ public class MutationConditionRequiresResource implements IMutationCondition {
 	}
 
 	@Override
-	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
+	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1, IClimateProvider climate) {
 		TileEntity tile;
 		do {
 			pos = pos.down();

--- a/src/main/java/forestry/core/genetics/mutations/MutationConditionTemperature.java
+++ b/src/main/java/forestry/core/genetics/mutations/MutationConditionTemperature.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.core.genetics.mutations;
 
+import forestry.api.core.IClimateProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
@@ -32,9 +33,9 @@ public class MutationConditionTemperature implements IMutationCondition {
 	}
 
 	@Override
-	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
+	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1, IClimateProvider climate) {
 		Biome biome = world.getBiomeProvider().getBiome(pos);
-		EnumTemperature biomeTemperature = EnumTemperature.getFromBiome(biome, world, pos);
+		EnumTemperature biomeTemperature = climate.getTemperature();
 
 		if (biomeTemperature.ordinal() < minTemperature.ordinal() || biomeTemperature.ordinal() > maxTemperature.ordinal()) {
 			return 0;

--- a/src/main/java/forestry/core/genetics/mutations/MutationConditionTimeLimited.java
+++ b/src/main/java/forestry/core/genetics/mutations/MutationConditionTimeLimited.java
@@ -12,6 +12,7 @@ package forestry.core.genetics.mutations;
 
 import java.util.Calendar;
 
+import forestry.api.core.IClimateProvider;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -32,7 +33,7 @@ public class MutationConditionTimeLimited implements IMutationCondition {
 	}
 
 	@Override
-	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
+	public float getChance(World world, BlockPos pos, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1, IClimateProvider climate) {
 		DayMonth now = new DayMonth();
 
 		// If we are equal to start day, return 1.

--- a/src/main/java/forestry/lepidopterology/genetics/ButterflyMutation.java
+++ b/src/main/java/forestry/lepidopterology/genetics/ButterflyMutation.java
@@ -35,7 +35,7 @@ public class ButterflyMutation extends Mutation implements IButterflyMutation, I
 	
 	@Override
 	public float getChance(World world, IButterflyNursery housing, IAllele allele0, IAllele allele1, IGenome genome0, IGenome genome1) {
-		float processedChance = super.getChance(world, housing.getCoordinates(), allele0, allele1, genome0, genome1);
+		float processedChance = super.getChance(world, housing.getCoordinates(), allele0, allele1, genome0, genome1, housing);
 		if (processedChance <= 0) {
 			return 0;
 		}


### PR DESCRIPTION
Before the big rewrite of mutations IBeeHousing could override the biome/temperature/humidity for mutation check purposes. This was used by Gendustry industrial apiaries with biome override upgrades.

After the rewrite the new MutationCondition\* classes get the biome directly from the world, not allowing for overriding from the apiary.

This PR changes that by adding a new interface IClimateProvider that lets mutation conditions check the climate while allowing it to be overriden. IBeeHousing and IButterflyNursery extend that interface while for trees a default implementation is provided in DefaultClimateProvider.

It includes some API changes, with the biggest one being IMutationCondition.getChance signature. The rest are probably not going to affect anybody.

I've discussed it on IRC with @Vexatos but didn't catch @mezz to talk about it. The relevant discussion is [here](https://gist.github.com/bdew/54bedfe5c1c6788b665f2f9817762f26).

I wasn't sure about exposing the default provider in the API, it could be useful for mods that have their own mutations (e.g. Botany). I could possibly add something like IClimateManager.getDefaultClimate(World world, BlockPos pos) if there's interest.
