### PR TITLE
IC2Classic Compat Fix

### DIFF
--- a/src/main/java/forestry/plugins/compat/PluginIC2.java
+++ b/src/main/java/forestry/plugins/compat/PluginIC2.java
@@ -58,6 +58,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
 
@@ -168,6 +169,10 @@ public class PluginIC2 extends BlankForestryPlugin {
 		ICrateRegistry crateRegistry = StorageManager.crateRegistry;
 		if (crateRegistry == null) {
 			return;
+		}
+		if(Loader.isModLoaded("IC2-Classic-Spmod")) //Needs to be lowercased with 1.11
+		{
+			return;//Prevents that Classic Items get loaded into crates and cause a renderCrash. Fix Until renderer is Fixed
 		}
 
 		if (resin != null) {


### PR DESCRIPTION
Fixes the Render Crash by excluding the Items from the Crates.
Just a Temporary Fix. The Renderer needs to be rewritten to support CodeGenerated Models & None Forge Models & ItemMeshDefinition.
