### PR TITLE
Crate Render Fix.

### DIFF
--- a/src/main/java/forestry/core/models/ModelCrate.java
+++ b/src/main/java/forestry/core/models/ModelCrate.java
@@ -10,159 +10,59 @@
  ******************************************************************************/
 package forestry.core.models;
 
-import com.google.common.base.Charsets;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import org.apache.commons.io.IOUtils;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ItemOverrideList;
-import net.minecraft.client.renderer.block.model.ModelBlock;
-import net.minecraft.client.resources.IResource;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
-import net.minecraft.item.Item;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.client.ItemModelMesherForge;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.model.IModel;
 import net.minecraftforge.client.model.IPerspectiveAwareModel;
 import net.minecraftforge.client.model.ModelLoaderRegistry;
 import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import forestry.core.items.ItemCrated;
 import forestry.core.utils.ItemStackUtil;
-import forestry.core.utils.Log;
 import forestry.storage.PluginStorage;
-
-import gnu.trove.map.hash.TIntObjectHashMap;
 
 @SideOnly(Side.CLIENT)
 public class ModelCrate extends BlankModel {
 
-	private static final Cache<String, IBakedModel> cache = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.MINUTES).build();
+	//Cache not needed because each baked quad is only 116 bytes big (minium size) and you do not have more then 1000 CrateTypes would only eat up 8 MB of ram.
+	private static Map<String, IBakedModel> cache = new HashMap<String, IBakedModel>();
 	private static final String CUSTOM_CRATES = "forestry:item/crates/";
 
-	private static IModel crateModel;
-	private static ModelBlock MODEL_GENERATED;
-    private static ModelBlock MODEL_ENTITY;
+//	private static IModel crateModel;
 
 	/**
 	 * Init the model with datas from the ModelBakeEvent.
 	 */
 	public static void onModelBake(ModelBakeEvent event){
-		try {
-			crateModel = ModelLoaderRegistry.getModel(new ResourceLocation("forestry:item/crate-filled"));
-			MODEL_GENERATED = ObfuscationReflectionHelper.getPrivateValue(ModelBakery.class, event.getModelLoader(), 17);
-			MODEL_ENTITY = ObfuscationReflectionHelper.getPrivateValue(ModelBakery.class, event.getModelLoader(), 18);
-		} catch (Exception e) {
-			Log.error("Failed to init the crate model.", e);
-		}
-		ModelCrate.cache.invalidateAll();
+//		try {
+//			crateModel = ModelLoaderRegistry.getModel(new ResourceLocation("forestry:item/crate-filled"));
+//		} catch (Exception e) {
+//			Log.error("Failed to init the crate model.", e);
+//		}
+//		ModelCrate.cache.invalidateAll();
+		cache.clear();
 	}
 
-	/**
-	 * @return The item model ResourceLocation from a ModelResourceLocation
-	 */
-	private ResourceLocation getItemLocation(ModelResourceLocation modelResource) {
-		ResourceLocation resourcelocation = new ResourceLocation(modelResource.toString().replaceAll("#.*", ""));
-		return new ResourceLocation(resourcelocation.getResourceDomain(), "item/" + resourcelocation.getResourcePath());
-	}
-
-	/**
-	 * @return Return true, when the model a item model is.
-	 */
-	private boolean hasItemModel(ResourceLocation location) {
-		try {
-			ModelBlock modelBlock = loadModel(location);
-			if (modelBlock == null) {
-				return false;
-			} else {
-				return modelBlock.getRootModel() == MODEL_GENERATED;
-			}
-		} catch (IOException e) {
-			return false;
-		}
-	}
-	
-	/**
-	 * @return Load a model from the location.
-	 */
-    private ModelBlock loadModel(ResourceLocation location) throws IOException{
-        Reader reader = null;
-        IResource iresource = null;
-        ModelBlock model;
-
-        try{
-            String s = location.getResourcePath();
-
-            if (!"builtin/generated".equals(s)){
-                if ("builtin/entity".equals(s)){
-                    model = MODEL_ENTITY;
-                    return model;
-                }
-
-                if (s.startsWith("builtin/")) {
-    				String s1 = s.substring("builtin/".length());
-    				if (s1.equals("missing")) {
-    					reader = new StringReader("{ \"textures\": {   \"particle\": \"missingno\",   \"missingno\": \"missingno\"}, \"elements\": [ {     \"from\": [ 0, 0, 0 ],     \"to\": [ 16, 16, 16 ],     \"faces\": {         \"down\":  { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"down\", \"texture\": \"#missingno\" },         \"up\":    { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"up\", \"texture\": \"#missingno\" },         \"north\": { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"north\", \"texture\": \"#missingno\" },         \"south\": { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"south\", \"texture\": \"#missingno\" },         \"west\":  { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"west\", \"texture\": \"#missingno\" },         \"east\":  { \"uv\": [ 0, 0, 16, 16 ], \"cullface\": \"east\", \"texture\": \"#missingno\" }    }}]}");
-    				} else {
-    					throw new FileNotFoundException(location.toString());
-    				}
-    			}else{
-                     iresource = Minecraft.getMinecraft().getResourceManager().getResource(this.getModelLocation(location));
-                    reader = new InputStreamReader(iresource.getInputStream(), Charsets.UTF_8);
-                }
-
-                model = ModelBlock.deserialize(reader);
-                model.name = location.toString();
-                if (model != null && model.getParentLocation() != null) {
-    				if (model.getParentLocation().getResourcePath().equals("builtin/generated")) {
-    					model.parent = MODEL_GENERATED;
-    				} else {
-    					try {
-    						model.parent = loadModel(model.getParentLocation());
-    					} catch (IOException e) {
-    						Log.error("Failed to load model.", e);
-    					}
-    				}
-    			} 
-                return model;
-            }
-
-            model = MODEL_GENERATED;
-        }
-        finally{
-            IOUtils.closeQuietly(reader);
-            IOUtils.closeQuietly(iresource);
-        }
-
-        return model;
-    }
-
-	private ResourceLocation getModelLocation(ResourceLocation resourceLocation) {
-		return new ResourceLocation(resourceLocation.getResourceDomain(), "models/" + resourceLocation.getResourcePath() + ".json");
-	}
 
 	/**
 	 * @return The model from the item of the stack.
@@ -176,50 +76,16 @@ public class ModelCrate extends BlankModel {
 		return new CrateOverrideList();
 	}
 	
-	private static IModel getCustomContentModel(ItemCrated crateItem){
-		ItemStack contained =  crateItem.getContained();
-		if(contained != null){
-			try {
-				return ModelLoaderRegistry.getModel(getCustomContentModelLocation(crateItem));
-			} catch (Exception e) {
-				return null;
-			}
-		}
-		return null;
-	}
-	
-	private static ResourceLocation getCustomContentModelLocation(ItemCrated crateItem){
-		String containedName = crateItem.getRegistryName().getResourcePath().replace("crated.", "");
-		return new ResourceLocation(CUSTOM_CRATES + containedName);
-		
-	}
-	
 	/**
 	 * Bake the crate model.
 	 */
-	private List<IBakedModel> bakeModel(ItemCrated crateItem, IBakedModel crateModel) {
+	private List<IBakedModel> bakeModel(ItemCrated crateItem) {
 		List<IBakedModel> models = new ArrayList<>();
-
-		IBakedModel containedModel = getModel(crateItem.getContained());
-		IModel customContentModel = getCustomContentModel(crateItem);
-
-		IdentityHashMap<Item, TIntObjectHashMap<ModelResourceLocation>> modelResourceLocations = ObfuscationReflectionHelper.getPrivateValue(ItemModelMesherForge.class, (ItemModelMesherForge) Minecraft.getMinecraft().getRenderItem().getItemModelMesher(), 0);
-
-		ModelResourceLocation modelResource = modelResourceLocations.get(crateItem.getContained().getItem()).get(crateItem.getContained().getItemDamage());
-		ResourceLocation location = getItemLocation(modelResource);
-
-		models.add(crateModel);
-		
-		if(customContentModel != null){
-			containedModel = customContentModel.bake(ModelManager.getInstance().DEFAULT_ITEM, DefaultVertexFormats.ITEM, new DefaultTextureGetter());
-			location = getCustomContentModelLocation(crateItem);
-		}
-		
-		if (hasItemModel(location)) {
+		ItemStack contained = crateItem.getContained();
+		if (contained != null) {
+			IBakedModel containedModel = getModel(contained);
 			models.add(new TRSRBakedModel(containedModel, -0.0625F, 0, 0.0625F, 0.5F));
 			models.add(new TRSRBakedModel(containedModel, -0.0625F, 0, -0.0625F, 0.5F));
-		} else {
-			models.add(new TRSRBakedModel(containedModel, -0.0625F, 0, 0, 0.5F));
 		}
 		return models;
 	}
@@ -227,7 +93,7 @@ public class ModelCrate extends BlankModel {
 	private class CrateOverrideList extends ItemOverrideList{
 		
 		public CrateOverrideList() {
-			super(Collections.emptyList());
+			super(new ArrayList());
 		}
 		
 		/**
@@ -237,37 +103,44 @@ public class ModelCrate extends BlankModel {
 		public IBakedModel handleItemState(IBakedModel originalModel, ItemStack stack, World world, EntityLivingBase entity) {
 			ItemCrated crated = (ItemCrated) stack.getItem();
 			String crateUID = ItemStackUtil.getItemNameFromRegistry(crated).getResourcePath();
-			if (cache.getIfPresent(crateUID) == null) {
+			IBakedModel model = cache.get(crateUID);
+			if(model == null)
+			{
+				//Fastest list with a unknown quad size
+				List<BakedQuad> list = new LinkedList<BakedQuad>();
 				IBakedModel baseBaked = getModel(new ItemStack(PluginStorage.items.crate, 1, 1));
-				//Set the crate color index to 100
-				for (BakedQuad quad : baseBaked.getQuads(null, null, 0)) {
-					ObfuscationReflectionHelper.setPrivateValue(BakedQuad.class, quad, 100, 1);
+				for(BakedQuad quad : baseBaked.getQuads(null, null, 0L))
+				{
+					list.add(new BakedQuad(quad.getVertexData(), 100, quad.getFace(), quad.getSprite(), quad.shouldApplyDiffuseLighting(), quad.getFormat()));
 				}
-				
-				cache.put(crateUID, new IPerspectiveAwareModel.MapWrapper(new CrateBakedModel( bakeModel(crated, baseBaked)), ModelManager.getInstance().DEFAULT_ITEM));
+				List<IBakedModel> textures = bakeModel(crated);
+				for(IBakedModel bakybake : textures)
+				{
+					list.addAll(bakybake.getQuads(null, null, 0L));
+				}
+				model = new BakedCrateModel(list);
+				cache.put(crateUID, model);
 			}
-			return cache.getIfPresent(crateUID);
+			return model;
 		}
 		
 	}
 	
-	private class CrateBakedModel extends BlankModel{
-
-		public final List<IBakedModel> models;
+	public static class BakedCrateModel extends BlankModel
+	{
+		List<BakedQuad> quads = new ArrayList<BakedQuad>();
+		private List<BakedQuad> emptyList = new ArrayList<BakedQuad>();
 		
-		public CrateBakedModel(List<IBakedModel> models) {
-			this.models = models;
+		public BakedCrateModel(List<BakedQuad> data)
+		{
+			quads.addAll(data);
 		}
 		
 		@Override
-		public List<BakedQuad> getQuads(IBlockState state, EnumFacing side, long rand) {
-			List<BakedQuad> quads = new ArrayList<>();
-			for(IBakedModel bakedModel : models){
-				quads.addAll(bakedModel.getQuads(null, side, rand++));	
-			}
-			return quads;
+		public List<BakedQuad> getQuads(@Nullable IBlockState state, @Nullable EnumFacing side, long rand)
+		{
+			return side == null ? quads : emptyList;
 		}
-		
 	}
     
 	@Override

--- a/src/main/java/forestry/core/models/ModelCrate.java
+++ b/src/main/java/forestry/core/models/ModelCrate.java
@@ -65,7 +65,7 @@ public class ModelCrate extends BlankModel {
 	 */
 	public static void onModelBake(ModelBakeEvent event){
 		cache.clear();
-		itemTransforms = getMap(new ResourceLocation("minecraft:models/item/handheld"));
+		itemTransforms = getMap(new ResourceLocation("minecraft:models/item/generated"));
 	}
 	
 	public static ImmutableMap<ItemCameraTransforms.TransformType, TRSRTransformation> getMap(ResourceLocation par1)

--- a/src/main/java/forestry/core/models/ModelCrate.java
+++ b/src/main/java/forestry/core/models/ModelCrate.java
@@ -44,7 +44,6 @@ import forestry.storage.PluginStorage;
 @SideOnly(Side.CLIENT)
 public class ModelCrate extends BlankModel {
 
-	//Cache not needed because each baked quad is only 116 bytes big (minium size) and you do not have more then 1000 CrateTypes would only eat up 8 MB of ram.
 	private static Map<String, IBakedModel> cache = new HashMap<String, IBakedModel>();
 	private static final String CUSTOM_CRATES = "forestry:item/crates/";
 

--- a/src/main/java/forestry/core/models/ModelCrate.java
+++ b/src/main/java/forestry/core/models/ModelCrate.java
@@ -48,18 +48,10 @@ public class ModelCrate extends BlankModel {
 	private static Map<String, IBakedModel> cache = new HashMap<String, IBakedModel>();
 	private static final String CUSTOM_CRATES = "forestry:item/crates/";
 
-//	private static IModel crateModel;
-
 	/**
 	 * Init the model with datas from the ModelBakeEvent.
 	 */
 	public static void onModelBake(ModelBakeEvent event){
-//		try {
-//			crateModel = ModelLoaderRegistry.getModel(new ResourceLocation("forestry:item/crate-filled"));
-//		} catch (Exception e) {
-//			Log.error("Failed to init the crate model.", e);
-//		}
-//		ModelCrate.cache.invalidateAll();
 		cache.clear();
 	}
 


### PR DESCRIPTION
The Code is now much cleaner, Faster & Way More efficient.
If you want to copy textures do it like this. No reflection required. Also supports Color Multiplier properly. (Yes you can change easy the colormultiplier just by recreating the Quad without memory usage increase)
Also its caching all cases since 1 Quad is eating up like 116 bytes, And you will have only 3 of them * the the create amount. Still you will never get into critical issues with this system.

And if this crashes with a mod then Minecraft would also crash with the model they injected into Minecraft. So this is safe it "Should" never break in any case. "Note: Only code inside this class TRSRBakedModel not included"

Also thanks to my system of not recreating a quadList everytime you get asked for quads you save over time a lot of performance.
(Perfection OCD for the win)
Please import that as soon as possible. Because i really need this and i do not want to publish a custom forestry version.