### PR TITLE
slightly offset the front and back part of the machine model to prevent Z fighting

### DIFF
--- a/src/main/java/forestry/core/render/RenderMachine.java
+++ b/src/main/java/forestry/core/render/RenderMachine.java
@@ -45,13 +45,13 @@ public class RenderMachine extends TileEntitySpecialRenderer<TileBase> {
 		ModelBase model = new RenderModelBase();
 
 		basefront = new ModelRenderer(model, 0, 0);
-		basefront.addBox(-8F, -8F, -8F, 16, 4, 16);
+		basefront.addBox(-8F, -7.9F, -8F, 16, 4, 16);
 		basefront.rotationPointX = 8;
 		basefront.rotationPointY = 8;
 		basefront.rotationPointZ = 8;
 
 		baseback = new ModelRenderer(model, 0, 0);
-		baseback.addBox(-8F, 4F, -8F, 16, 4, 16);
+		baseback.addBox(-8F, 3.9F, -8F, 16, 4, 16);
 		baseback.rotationPointX = 8;
 		baseback.rotationPointY = 8;
 		baseback.rotationPointZ = 8;


### PR DESCRIPTION
This shows the Z fighting (Sphax Texturepack, Optifine)
![forestry_z_fighting](https://cloud.githubusercontent.com/assets/6777029/23189006/29eacf18-f891-11e6-8ddc-dded82318170.png)

This is with the small offset (No texture pack, Optifine)
![forestry_small_offset](https://cloud.githubusercontent.com/assets/6777029/23189009/2f7a9d78-f891-11e6-83a5-7770d33baa52.png)
