### PR TITLE
Fix names in BC|Transport compat

### DIFF
--- a/src/main/java/forestry/plugins/compat/PluginBuildCraftTransport.java
+++ b/src/main/java/forestry/plugins/compat/PluginBuildCraftTransport.java
@@ -26,7 +26,7 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 @ForestryPlugin(pluginID = ForestryPluginUids.BUILDCRAFT_TRANSPORT, name = "BuildCraft 6 Transport", author = "mezz", url = Constants.URL, unlocalizedDescription = "for.plugin.buildcraft6.description")
 public class PluginBuildCraftTransport extends BlankForestryPlugin {
 
-	private static final String BCT = "BuildCraft|Transport";
+	private static final String BCT = "buildcrafttransport";
 
 	@Override
 	public boolean isAvailable() {
@@ -35,13 +35,13 @@ public class PluginBuildCraftTransport extends BlankForestryPlugin {
 
 	@Override
 	public String getFailMessage() {
-		return "BuildCraft|Transport not found";
+		return "buildcrafttransport not found";
 	}
 
 	@Override
 	public void registerRecipes() {
 		Item beeswax = PluginCore.getItems().beeswax;
-		Item pipeWaterproof = ForgeRegistries.ITEMS.getValue(new ResourceLocation(BCT, "pipeWaterproof"));
+		Item pipeWaterproof = ForgeRegistries.ITEMS.getValue(new ResourceLocation(BCT, "waterproof"));
 		if (pipeWaterproof != null) {
 			RecipeUtil.addShapelessRecipe(new ItemStack(pipeWaterproof), beeswax);
 		} else {


### PR DESCRIPTION
As with the update to 1.11 BC|Transport now has a modid of "buildcrafttransport", and the pipeWaterproof has been renamed to "waterproof".

You *might* want to rename this plugin from "BuildCraft 6 Transport" to "BuildCraft 8 Transport" - but that's minor.

The api for getting BC items is [here](https://github.com/BuildCraft/BuildCraftAPI/blob/8.0.x/api/buildcraft/api/BCItems.java#L123), so thet's where the registry names came from (and they won't be changed in 8.0.x or 7.99.x) in case I've made a mistake.

*EDIT:* I won't PR the other compat's until I'm certain that the BC|API won't change for those modules. I'm also not sure what todo with the refinery recipe as BC doesn't use a refinery any more for oil processing.