### PR TITLE
Update modids for Natura and Extra Utilities 2

### DIFF
--- a/src/main/java/forestry/plugins/compat/PluginExtraUtilities.java
+++ b/src/main/java/forestry/plugins/compat/PluginExtraUtilities.java
@@ -41,7 +41,7 @@ import net.minecraftforge.fml.common.registry.ForgeRegistries;
 @ForestryPlugin(pluginID = ForestryPluginUids.EXTRA_UTILITIES, name = "ExtraUtilities", author = "Nirek", url = Constants.URL, unlocalizedDescription = "for.plugin.extrautilities.description")
 public class PluginExtraUtilities extends BlankForestryPlugin {
 
-	private static final String ExU = "ExtraUtils2";
+	private static final String ExU = "extrautils2";
 
 	@Override
 	public boolean isAvailable() {

--- a/src/main/java/forestry/plugins/compat/PluginNatura.java
+++ b/src/main/java/forestry/plugins/compat/PluginNatura.java
@@ -41,7 +41,7 @@ import forestry.plugins.ForestryPluginUids;
 @ForestryPlugin(pluginID = ForestryPluginUids.NATURA, name = "Natura", author = "SirSengir", url = Constants.URL, unlocalizedDescription = "for.plugin.natura.description")
 public class PluginNatura extends BlankForestryPlugin {
 
-	private static final String NATURA = "Natura";
+	private static final String NATURA = "natura";
 
 	private static Block logNatura;
 	private static Block logWillow;


### PR DESCRIPTION
It seems they follow the lowercase modid recommendation now.
It's a simple fix for newer versions.
This will break compatibility with older version of these mods.

Maybe it would be better to allow lower and uppercase names?