### PR TITLE
Update to AA r115

### DIFF
--- a/src/main/java/forestry/plugins/compat/PluginActuallyAdditions.java
+++ b/src/main/java/forestry/plugins/compat/PluginActuallyAdditions.java
@@ -72,7 +72,7 @@ public class PluginActuallyAdditions extends BlankForestryPlugin {
 			}
 
 			//add canola oil fermenting in still
-			Fluid oil = getFluid("oil");
+			Fluid oil = getFluid("refinedcanolaoil");
 			if (oil != null) {
 				RecipeManagers.stillManager.addRecipe(200, new FluidStack(canolaOil, 5), new FluidStack(oil, 5));
 			}


### PR DESCRIPTION
The fluid "Oil" in actually additions was changed to "Refined Canola Oil" as of r115, to avoid conflicts with other mods using oil, as it is not equivalent.