### PR TITLE
Change event listeners to newer event system + sample fix for natura

### DIFF
--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -15,7 +15,10 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 import java.io.File;
 
+import forestry.plugins.compat.PluginNatura;
+import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.FluidRegistry;
 
 import net.minecraftforge.fml.common.Mod;
@@ -26,6 +29,7 @@ import net.minecraftforge.fml.common.event.FMLInterModComms.IMCEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 
@@ -58,7 +62,8 @@ import forestry.plugins.compat.PluginIC2;
 		acceptedMinecraftVersions = "[1.12]",
 		dependencies = "required-after:forge@[14.21.1.2395,);"
 				+ "after:jei@[4.7.0,);"
-				+ "after:" + PluginIC2.modId + ";")
+				+ "after:" + PluginIC2.modId + ";"
+				+ "after:" + PluginNatura.modId + ";")
 public class Forestry {
 
 	@SuppressWarnings("NullableProblems")
@@ -73,6 +78,7 @@ public class Forestry {
 		ForestryAPI.errorStateRegistry = new ErrorStateRegistry();
 		EnumErrorCode.init();
 		FluidRegistry.enableUniversalBucket();
+		MinecraftForge.EVENT_BUS.register(this);
 	}
 
 	@Nullable
@@ -105,6 +111,11 @@ public class Forestry {
 
 		PluginManager.runPreInit(event.getSide());
 
+	}
+
+	@SubscribeEvent
+	public void registerModels(ModelRegistryEvent event) {
+		PluginManager.runRegisterBackpacksAndCrates();
 		Proxies.render.registerModels();
 	}
 

--- a/src/main/java/forestry/plugins/PluginManager.java
+++ b/src/main/java/forestry/plugins/PluginManager.java
@@ -66,7 +66,8 @@ public class PluginManager {
 		SETUP, // setup API to make it functional. GameMode Configs are not yet accessible
 		SETUP_DISABLED, // setup fallback API to avoid crashes
 		REGISTER, // register basic blocks and items
-		PRE_INIT, // register handlers, triggers, definitions, backpacks, crates, and anything that depends on basic items
+		PRE_INIT, // register handlers, triggers, definitions, and anything that depends on basic items
+		BACKPACKS_CRATES, // backpacks, crates
 		INIT, // anything that depends on PreInit stages, recipe registration
 		POST_INIT, // stubborn mod integration, dungeon loot, and finalization of things that take input from mods
 		FINISHED
@@ -228,11 +229,19 @@ public class PluginManager {
 			if (ForestryAPI.enabledPlugins.contains(ForestryPluginUids.BUILDCRAFT_STATEMENTS)) {
 				plugin.registerTriggers();
 			}
+			Log.debug("Pre-Init Complete: {}", plugin);
+		}
+	}
+
+	public static void runRegisterBackpacksAndCrates() {
+		stage = Stage.BACKPACKS_CRATES;
+		for (IForestryPlugin plugin : loadedPlugins) {
 			if (ForestryAPI.enabledPlugins.contains(ForestryPluginUids.STORAGE)) {
+				Log.debug("BackpacksAndCrates Start: {}", plugin);
 				plugin.registerBackpackItems();
 				plugin.registerCrates();
+				Log.debug("BackpacksAndCrates Complete: {}", plugin);
 			}
-			Log.debug("Pre-Init Complete: {}", plugin);
 		}
 	}
 


### PR DESCRIPTION
This is mainly for discussion on how to approach upcoming problems due to event api changes.

This is a trial and error solution to get a client up and running with changes introduced somewhere between 1.8 and 1.12.
Some mods (including Natura) are using RegistryEvents now. Those events are fired AFTER preInit making any preInit item look ups silently fail.
To fix this the inner workings of Forestry need to redesigned and moved around.
There are some unresolved issues (see comments)

I would use this as a discussion on how to tackle the problem, while providing a glance at some of the required changes.

This whole changeset is not really tested.
Especially everything model related etc. is totally untested. I do not have enough knowledge of the design of Forestry to see if moving some stuff around is actually the right thing to do here and there.

Additionally there will be some more changes to clean some mess up that is already in the code base. (See comments)