### PR TITLE
MultiFarm fix for HarvestCraft plugin

### DIFF
--- a/src/main/java/forestry/plugins/compat/PluginHarvestCraft.java
+++ b/src/main/java/forestry/plugins/compat/PluginHarvestCraft.java
@@ -58,7 +58,7 @@ public class PluginHarvestCraft extends BlankForestryPlugin {
 	
 	@Nullable
 	private static ItemStack getItemStack(@Nonnull String itemName) {
-		ResourceLocation key = new ResourceLocation(HC, itemName);
+		ResourceLocation key = new ResourceLocation(HC, itemName.toLowerCase());
 		if (ForgeRegistries.ITEMS.containsKey(key)) {
 			return new ItemStack(ForgeRegistries.ITEMS.getValue(key),1);
 		} else {
@@ -66,7 +66,7 @@ public class PluginHarvestCraft extends BlankForestryPlugin {
 		}
 	}
 	private static Block getBlock(@Nonnull String blockName) {
-		ResourceLocation key = new ResourceLocation(HC, blockName);
+		ResourceLocation key = new ResourceLocation(HC, blockName.toLowerCase());
 		if (ForgeRegistries.BLOCKS.containsKey(key)) {
 			return ForgeRegistries.BLOCKS.getValue(key);
 		} else {


### PR DESCRIPTION
In new implementation Items have name in lowercase, and forestry can't to find it.