### PR TITLE
Fix issue #1872

### DIFF
--- a/src/main/java/forestry/factory/recipes/FermenterRecipe.java
+++ b/src/main/java/forestry/factory/recipes/FermenterRecipe.java
@@ -92,6 +92,7 @@ public class FermenterRecipe implements IFermenterRecipe {
 
 	@Override
 	public int compareTo(IFermenterRecipe o) {
-		return resource.isEmpty() ? 1 : 0;
+		return resource.isEmpty()
+			&& resourceOreName.isEmpty() ? 0 : 1;
 	}
 }


### PR DESCRIPTION
Fix issue #1872
Fix wrong `FermenterRecipe#compareTo`.
Recipes without concrete item and with resourceOreName was ignored.