### PR TITLE
use biomesoplenty's correct fml name (fixes #1870)

### DIFF
--- a/src/main/java/forestry/plugins/compat/PluginBiomesOPlenty.java
+++ b/src/main/java/forestry/plugins/compat/PluginBiomesOPlenty.java
@@ -39,7 +39,7 @@ import net.minecraftforge.oredict.OreDictionary;
 @ForestryPlugin(pluginID = ForestryPluginUids.BIOMES_O_PLENTY, name = "BiomesOPlenty", author = "Nirek", url = Constants.URL, unlocalizedDescription = "for.plugin.biomesoplenty.description")
 public class PluginBiomesOPlenty extends BlankForestryPlugin {
 
-	private static final String BoP = "BiomesOPlenty";
+	private static final String BoP = "biomesoplenty";
 
 	@Nullable
 	private static Block saplings;


### PR DESCRIPTION
The BiomesOPlenty compat module isn't being installed because it's looking for the FML name "BiomesOPlenty" instead of all-lowercase "biomesoplenty". Once this change is made, the module is activated as expected.