### PR TITLE
Add power config for Analyzer

### DIFF
--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -71,6 +71,7 @@ public class Config {
 
 	// Genetics
 	public static boolean pollinateVanillaTrees = true;
+	public static int analyzerEnergyPerWork = 20320;
 	public static float researchMutationBoostMultiplier = 1.5f;
 	public static float maxResearchMutationBoostPercent = 5.0f;
 
@@ -239,6 +240,7 @@ public class Config {
 		}
 
 		pollinateVanillaTrees = configCommon.getBooleanLocalized("genetics", "pollinate.vanilla.trees", pollinateVanillaTrees);
+		analyzerEnergyPerWork = configCommon.getIntLocalized("genetics", "analyzerblock.energy.use", 20320, 0, 100000);
 		researchMutationBoostMultiplier = configCommon.getFloatLocalized("genetics.research.boost", "multiplier", researchMutationBoostMultiplier, 1.0f, 1000.f);
 		maxResearchMutationBoostPercent = configCommon.getFloatLocalized("genetics.research.boost", "max.percent", maxResearchMutationBoostPercent, 0.0f, 100.0f);
 

--- a/src/main/java/forestry/core/tiles/TileAnalyzer.java
+++ b/src/main/java/forestry/core/tiles/TileAnalyzer.java
@@ -34,6 +34,7 @@ import forestry.api.arboriculture.TreeManager;
 import forestry.api.core.ForestryAPI;
 import forestry.api.genetics.AlleleManager;
 import forestry.api.genetics.IIndividual;
+import forestry.core.config.Config;
 import forestry.core.config.Constants;
 import forestry.core.errors.EnumErrorCode;
 import forestry.core.fluids.FilteredTank;
@@ -54,7 +55,7 @@ import forestry.modules.ForestryModuleUids;
 public class TileAnalyzer extends TilePowered implements ISidedInventory, ILiquidTankTile, IItemStackDisplay {
 	private static final int TIME_TO_ANALYZE = 125;
 	private static final int HONEY_REQUIRED = 100;
-	private static final int ENERGY_PER_WORK_CYCLE = 20320;
+	private static final int ENERGY_PER_WORK_CYCLE = Config.analyzerEnergyPerWork;
 
 	private final FilteredTank resourceTank;
 	private final TankManager tankManager;

--- a/src/main/java/forestry/core/tiles/TileAnalyzer.java
+++ b/src/main/java/forestry/core/tiles/TileAnalyzer.java
@@ -55,7 +55,6 @@ import forestry.modules.ForestryModuleUids;
 public class TileAnalyzer extends TilePowered implements ISidedInventory, ILiquidTankTile, IItemStackDisplay {
 	private static final int TIME_TO_ANALYZE = 125;
 	private static final int HONEY_REQUIRED = 100;
-	private static final int ENERGY_PER_WORK_CYCLE = Config.analyzerEnergyPerWork;
 
 	private final FilteredTank resourceTank;
 	private final TankManager tankManager;
@@ -235,7 +234,7 @@ public class TileAnalyzer extends TilePowered implements ISidedInventory, ILiqui
 			setEnergyPerWorkCycle(0);
 		} else {
 			setTicksPerWorkCycle(TIME_TO_ANALYZE);
-			setEnergyPerWorkCycle(ENERGY_PER_WORK_CYCLE);
+			setEnergyPerWorkCycle(Config.analyzerEnergyPerWork);
 		}
 
 		PacketItemStackDisplay packet = new PacketItemStackDisplay(this, getIndividualOnDisplay());


### PR DESCRIPTION
Adds a config option to control power used per tick of the analyzer block to close https://github.com/ForestryMC/ForestryMC/issues/1881. 

I think this is ok for balance but if it isn't we can set a minimum or remove this. Also, if this is poorly implemented please remove.

Hope this helps.