### PR TITLE
Add whitelist for generation based on dimension

### DIFF
--- a/src/main/java/forestry/apiculture/HiveConfig.java
+++ b/src/main/java/forestry/apiculture/HiveConfig.java
@@ -23,11 +23,16 @@ public class HiveConfig {
 	private final Set<Biome> blacklistedBiomes = new HashSet<>();
 
 	private static final Set<Integer> blacklistedDims = new HashSet<>();
+	
+	private static final Set<Integer> whitelistedDims = new HashSet<>();
 
 	public static void parse(LocalizedConfiguration config){
 		config.addCategoryCommentLocalized(CATEGORY);
 		for(int dimId : config.get("world.generate.beehives", "dimBlacklist", new int[0]).getIntList()){
 			blacklistedDims.add(dimId);
+		}
+		for(int dimId : config.get("world.generate.beehives", "dimWhitelist", new int[0]).getIntList()) {
+			whitelistedDims.add(dimId);
 		}
 		for(IHiveRegistry.HiveType type : IHiveRegistry.HiveType.values()){
 			String[] entries = config.get(CATEGORY, type.getName(), new String[0]).getStringList();
@@ -62,11 +67,18 @@ public class HiveConfig {
 		return BiomeDictionary.getTypes(biome).stream().anyMatch(blacklistedTypes::contains);
 	}
 	
-	public static boolean isDimBlacklisted(int dimId) {
-		return blacklistedDims.contains(dimId);
+	public static boolean isDimAllowed(int dimId) {		//blacklist has priority
+		if(blacklistedDims.isEmpty() || !blacklistedDims.contains(dimId)) {
+			return whitelistedDims.contains(dimId);
+		}
+		return false;
 	}
 	
 	public static void addBlacklistedDim(int dimId) {
 		blacklistedDims.add(dimId);
+	}
+	
+	public static void addWhitelistedDim(int dimId) {
+		whitelistedDims.add(dimId);
 	}
 }

--- a/src/main/java/forestry/apiculture/HiveConfig.java
+++ b/src/main/java/forestry/apiculture/HiveConfig.java
@@ -71,7 +71,7 @@ public class HiveConfig {
 		if(blacklistedDims.isEmpty() || !blacklistedDims.contains(dimId)) {
 			return whitelistedDims.isEmpty() || whitelistedDims.contains(dimId);
 		}
-		return true;
+		return false;
 	}
 	
 	public static void addBlacklistedDim(int dimId) {

--- a/src/main/java/forestry/apiculture/HiveConfig.java
+++ b/src/main/java/forestry/apiculture/HiveConfig.java
@@ -69,9 +69,9 @@ public class HiveConfig {
 	
 	public static boolean isDimAllowed(int dimId) {		//blacklist has priority
 		if(blacklistedDims.isEmpty() || !blacklistedDims.contains(dimId)) {
-			return whitelistedDims.contains(dimId);
+			return whitelistedDims.isEmpty() || whitelistedDims.contains(dimId);
 		}
-		return false;
+		return true;
 	}
 	
 	public static void addBlacklistedDim(int dimId) {

--- a/src/main/java/forestry/apiculture/worldgen/Hive.java
+++ b/src/main/java/forestry/apiculture/worldgen/Hive.java
@@ -67,7 +67,7 @@ public final class Hive {
 	}
 
 	public boolean isValidLocation(World world, BlockPos pos) {
-		if(HiveConfig.isDimBlacklisted(world.provider.getDimension())) {
+		if(!HiveConfig.isDimAllowed(world.provider.getDimension())) {
 			return false;
 		}
 		return hiveDescription.getHiveGen().isValidLocation(world, pos);

--- a/src/main/java/forestry/arboriculture/worldgen/TreeDecorator.java
+++ b/src/main/java/forestry/arboriculture/worldgen/TreeDecorator.java
@@ -55,8 +55,9 @@ public class TreeDecorator {
 	}
 
 	public static void decorateTrees(World world, Random rand, int worldX, int worldZ) {
-		if(Config.blacklistedTreeDims.contains(world.provider.getDimension()))
+		if(!Config.isValidTreeDim(world.provider.getDimension())) {
 			return;
+		}
 		if (biomeCache.isEmpty()) {
 			generateBiomeCache(world, rand);
 		}

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -80,12 +80,14 @@ public class Config {
 	public static boolean generateCopperOre = true;
 	public static boolean generateTinOre = true;
 	public static Set<Integer> blacklistedOreDims = new HashSet<Integer>();
+	public static Set<Integer> whitelistedOreDims = new HashSet<Integer>();
 	private static float generateBeehivesAmount = 1.0f;
 	public static boolean generateBeehivesDebug = false;
 	public static boolean logHivePlacement = false;
 	public static boolean enableVillagers = true;
 	public static boolean generateTrees = true;
 	public static Set<Integer> blacklistedTreeDims = new HashSet<Integer>();
+	public static Set<Integer> whitelistedTreeDims = new HashSet<Integer>();
 
 	// Retrogen
 	public static boolean doRetrogen = false;
@@ -163,8 +165,30 @@ public class Config {
 		blacklistedTreeDims.add(dimID);
 	}
 	
+	public static void whitelistTreeDim(int dimID) {
+		whitelistedTreeDims.add(dimID);
+	}
+	
 	public static void blacklistOreDim(int dimID) {
 		blacklistedOreDims.add(dimID);
+	}
+	
+	public static void whitelistOreDim(int dimID) {
+		whitelistedOreDims.add(dimID);
+	}
+	
+	public static boolean isValidOreDim(int dimID) {		//blacklist has priority
+		if(blacklistedOreDims.isEmpty() || !blacklistedOreDims.contains(dimID)) {
+			return whitelistedOreDims.contains(dimID);
+		}
+		return false;
+	}
+	
+	public static boolean isValidTreeDim(int dimID) { 		//blacklist has priority
+		if(blacklistedTreeDims.isEmpty() || !blacklistedTreeDims.contains(dimID)) {
+			return whitelistedTreeDims.contains(dimID);
+		}
+		return false;
 	}
 
 	public static void load(Side side) {
@@ -235,8 +259,11 @@ public class Config {
 		generateApatiteOre = configCommon.getBooleanLocalized("world.generate.ore", "apatite", generateApatiteOre);
 		generateCopperOre = configCommon.getBooleanLocalized("world.generate.ore", "copper", generateCopperOre);
 		generateTinOre = configCommon.getBooleanLocalized("world.generate.ore", "tin", generateTinOre);
-		for(int dimId : configCommon.get("world.generate.ore", "dimBlacklist", new int[0]).getIntList()){
+		for(int dimId : configCommon.get("world.generate.ore", "dimBlacklist", new int[0]).getIntList()) {
  			blacklistedOreDims.add(dimId);
+		}
+		for(int dimId : configCommon.get("world.generate.ore", "dimWhitelist", new int[0]).getIntList()) {
+			whitelistedOreDims.add(dimId);
 		}
 		
 		enableVillagers = configCommon.getBooleanLocalized("world.generate", "villagers", enableVillagers);
@@ -245,6 +272,9 @@ public class Config {
 		for(int dimId : configCommon.get("world.generate.trees", "dimBlacklist", new int[0]).getIntList()){
 			 			blacklistedTreeDims.add(dimId);
 		}
+		for(int dimId : configCommon.get("world.generate.trees", "dimWhitelist", new int[0]).getIntList()){
+ 			whitelistedTreeDims.add(dimId);
+}
 			 	
 		
 		craftingBronzeEnabled = configCommon.getBooleanLocalized("crafting", "bronze", craftingBronzeEnabled);

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -179,16 +179,16 @@ public class Config {
 	
 	public static boolean isValidOreDim(int dimID) {		//blacklist has priority
 		if(blacklistedOreDims.isEmpty() || !blacklistedOreDims.contains(dimID)) {
-			return whitelistedOreDims.contains(dimID);
+			return whitelistedOreDims.isEmpty() || whitelistedOreDims.contains(dimID);
 		}
-		return false;
+		return true;
 	}
 	
 	public static boolean isValidTreeDim(int dimID) { 		//blacklist has priority
 		if(blacklistedTreeDims.isEmpty() || !blacklistedTreeDims.contains(dimID)) {
-			return whitelistedTreeDims.contains(dimID);
+			return whitelistedTreeDims.isEmpty() || whitelistedTreeDims.contains(dimID);
 		}
-		return false;
+		return true;
 	}
 
 	public static void load(Side side) {

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -181,14 +181,14 @@ public class Config {
 		if(blacklistedOreDims.isEmpty() || !blacklistedOreDims.contains(dimID)) {
 			return whitelistedOreDims.isEmpty() || whitelistedOreDims.contains(dimID);
 		}
-		return true;
+		return false;
 	}
 	
 	public static boolean isValidTreeDim(int dimID) { 		//blacklist has priority
 		if(blacklistedTreeDims.isEmpty() || !blacklistedTreeDims.contains(dimID)) {
 			return whitelistedTreeDims.isEmpty() || whitelistedTreeDims.contains(dimID);
 		}
-		return true;
+		return false;
 	}
 
 	public static void load(Side side) {

--- a/src/main/java/forestry/core/worldgen/WorldGenerator.java
+++ b/src/main/java/forestry/core/worldgen/WorldGenerator.java
@@ -68,7 +68,7 @@ public class WorldGenerator implements IWorldGenerator {
 	}
 
 	private void generateWorld(Random random, int chunkX, int chunkZ, World world) {
-		if(Config.blacklistedOreDims.contains(world.provider.getDimension()))
+		if(!Config.isValidOreDim(world.provider.getDimension()))
 			return;
 
 		if (apatiteGenerator == null || copperGenerator == null || tinGenerator == null) {


### PR DESCRIPTION
Closes https://github.com/ForestryMC/ForestryMC/issues/1739. I don't think it's possible to change where the Apiarist village house will generate easily so I haven't touched that. However, I think it is possible to implement a whitelist as well for dimensions. This is designed for pack makers/players (eg - player has access to many dimensions early but pack maker wants to gate forestry until later) as the blacklist will take priority (as it should do in my opinion).

However, this is slightly messy. If there's a better way to do something like this let me know.