### PR TITLE
Add IMC to let mods add fertilizer

### DIFF
--- a/src/main/java/forestry/farming/ModuleFarming.java
+++ b/src/main/java/forestry/farming/ModuleFarming.java
@@ -47,8 +47,6 @@ import forestry.api.core.ForestryAPI;
 import forestry.api.farming.IFarmProperties;
 import forestry.api.farming.IFarmRegistry;
 import forestry.api.modules.ForestryModule;
-import forestry.apiculture.HiveConfig;
-import forestry.apiculture.blocks.BlockCandle;
 import forestry.core.ModuleCore;
 import forestry.core.blocks.BlockBogEarth;
 import forestry.core.blocks.BlockRegistryCore;
@@ -61,7 +59,6 @@ import forestry.core.items.EnumElectronTube;
 import forestry.core.items.ItemRegistryCore;
 import forestry.core.recipes.RecipeUtil;
 import forestry.core.utils.IMCUtil;
-import forestry.core.utils.Log;
 import forestry.core.utils.OreDictUtil;
 import forestry.farming.blocks.BlockMushroom;
 import forestry.farming.blocks.BlockRegistryFarming;
@@ -361,6 +358,8 @@ public class ModuleFarming extends BlankForestryModule {
 		EnumFarmBlockType.registerSprites();
 	}
 	
+	/* Only add your fertilizers here if they require sufficient setup/ are non renewable or add a low 
+	 * fertilizer value. This should be considered carefully*/
 	@Override
 	public boolean processIMCMessage(IMCMessage message) {
 		if (message.key.equals("add-fertilizer")) {

--- a/src/main/java/forestry/farming/ModuleFarming.java
+++ b/src/main/java/forestry/farming/ModuleFarming.java
@@ -33,6 +33,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.oredict.OreDictionary;
 
 import net.minecraftforge.fml.common.SidedProxy;
+import net.minecraftforge.fml.common.event.FMLInterModComms.IMCMessage;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
@@ -46,6 +47,8 @@ import forestry.api.core.ForestryAPI;
 import forestry.api.farming.IFarmProperties;
 import forestry.api.farming.IFarmRegistry;
 import forestry.api.modules.ForestryModule;
+import forestry.apiculture.HiveConfig;
+import forestry.apiculture.blocks.BlockCandle;
 import forestry.core.ModuleCore;
 import forestry.core.blocks.BlockBogEarth;
 import forestry.core.blocks.BlockRegistryCore;
@@ -57,6 +60,8 @@ import forestry.core.config.LocalizedConfiguration;
 import forestry.core.items.EnumElectronTube;
 import forestry.core.items.ItemRegistryCore;
 import forestry.core.recipes.RecipeUtil;
+import forestry.core.utils.IMCUtil;
+import forestry.core.utils.Log;
 import forestry.core.utils.OreDictUtil;
 import forestry.farming.blocks.BlockMushroom;
 import forestry.farming.blocks.BlockRegistryFarming;
@@ -354,5 +359,20 @@ public class ModuleFarming extends BlankForestryModule {
 	@SideOnly(Side.CLIENT)
 	public void handleTextureRemap(TextureStitchEvent.Pre event) {
 		EnumFarmBlockType.registerSprites();
+	}
+	
+	@Override
+	public boolean processIMCMessage(IMCMessage message) {
+		if (message.key.equals("add-fertilizer")) {
+			ItemStack value = message.getItemStackValue();
+			int fertilizerValue = Integer.parseInt(message.getStringValue());
+			if (value != null) {
+				ForestryAPI.farmRegistry.registerFertilizer(value, fertilizerValue);
+			} else {
+				IMCUtil.logInvalidIMCMessage(message);
+			}
+			return true;
+		}  
+		return false;
 	}
 }


### PR DESCRIPTION
This is more of an idea but since the PR is so easy to write I went ahead and implemented it.

 This PR adds a way for mods to add their fertilizers to work in a farm. There is already a config to do this so I don't think it's too unreasonable. However, this relies on some good faith in other mods not to add something which will break the balance of Forestry. This also means mods don't have to write a plugin and can just send a message instead.

If things just stay in the config then at least the only people who will add fertilizers are players dedicated enough to actually change default configs (!) or packmakers. This is probably good because these people will care about balance more.

Let me know what you think.