### PR TITLE
Stop peat fired engine outputting ash through power side

### DIFF
--- a/src/main/java/forestry/core/inventory/AdjacentInventoryCache.java
+++ b/src/main/java/forestry/core/inventory/AdjacentInventoryCache.java
@@ -69,6 +69,13 @@ public final class AdjacentInventoryCache implements AdjacentTileCache.ICacheLis
 		return invs;
 	}
 
+	public Collection<IItemHandler> getAdjacentInventoriesOtherThan(EnumFacing side) {
+		checkChanged();
+		Collection<IItemHandler> ret = getAdjacentInventories();
+		ret.remove(getAdjacentInventory(side));
+		return ret;
+	}
+
 	@Override
 	public void changed() {
 		changed = true;

--- a/src/main/java/forestry/energy/tiles/TileEnginePeat.java
+++ b/src/main/java/forestry/energy/tiles/TileEnginePeat.java
@@ -11,9 +11,11 @@
 package forestry.energy.tiles;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import forestry.api.fuels.FuelManager;
 import forestry.core.ModuleCore;
+import forestry.core.blocks.BlockBase;
 import forestry.core.config.Constants;
 import forestry.core.errors.EnumErrorCode;
 import forestry.core.inventory.AdjacentInventoryCache;
@@ -26,6 +28,7 @@ import forestry.core.utils.InventoryUtil;
 import forestry.energy.gui.ContainerEnginePeat;
 import forestry.energy.gui.GuiEnginePeat;
 import forestry.energy.inventory.InventoryEnginePeat;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -33,8 +36,11 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 
@@ -224,7 +230,9 @@ public class TileEnginePeat extends TileEngine implements ISidedInventory {
 		IItemHandler wasteItemHandler = new InvWrapper(wasteInventory);
 
 		if (!InventoryUtil.moveOneItemToPipe(wasteItemHandler, getTileCache())) {
-			InventoryUtil.moveItemStack(wasteItemHandler, inventoryCache.getAdjacentInventories());
+			EnumFacing powerSide = world.getBlockState(getPos()).getValue(BlockBase.FACING);
+			Collection<IItemHandler> inventories = inventoryCache.getAdjacentInventoriesOtherThan(powerSide);
+			InventoryUtil.moveItemStack(wasteItemHandler, inventories);
 		}
 	}
 
@@ -302,14 +310,14 @@ public class TileEnginePeat extends TileEngine implements ISidedInventory {
 
 	/* ITriggerProvider */
 	// TODO: buildcraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		LinkedList<ITriggerExternal> res = new LinkedList<>();
-//		res.add(FactoryTriggers.lowFuel25);
-//		res.add(FactoryTriggers.lowFuel10);
-//		return res;
-//	}
+	//	@Optional.Method(modid = "BuildCraftAPI|statements")
+	//	@Override
+	//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
+	//		LinkedList<ITriggerExternal> res = new LinkedList<>();
+	//		res.add(FactoryTriggers.lowFuel25);
+	//		res.add(FactoryTriggers.lowFuel10);
+	//		return res;
+	//	}
 
 	@Override
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/forestry/energy/tiles/TileEnginePeat.java
+++ b/src/main/java/forestry/energy/tiles/TileEnginePeat.java
@@ -13,6 +13,21 @@ package forestry.energy.tiles;
 import java.io.IOException;
 import java.util.Collection;
 
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.wrapper.InvWrapper;
+
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
 import forestry.api.fuels.FuelManager;
 import forestry.core.ModuleCore;
 import forestry.core.blocks.BlockBase;
@@ -28,21 +43,6 @@ import forestry.core.utils.InventoryUtil;
 import forestry.energy.gui.ContainerEnginePeat;
 import forestry.energy.gui.GuiEnginePeat;
 import forestry.energy.inventory.InventoryEnginePeat;
-
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.Container;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.inventory.ISidedInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
-
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
-import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.wrapper.InvWrapper;
 
 public class TileEnginePeat extends TileEngine implements ISidedInventory {
 	private ItemStack fuel = ItemStack.EMPTY;


### PR DESCRIPTION
closes https://github.com/ForestryMC/ForestryMC/issues/2009. Unless there's a good performance/gameplay reason it does (I guess it may help for some automation setups).