### PR TITLE
Move null checks for registering crates and backpacks

### DIFF
--- a/src/main/java/forestry/api/storage/IBackpackInterface.java
+++ b/src/main/java/forestry/api/storage/IBackpackInterface.java
@@ -11,9 +11,10 @@ import java.util.function.Predicate;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
-import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.registries.IForgeRegistryEntry;
+
+import net.minecraftforge.fml.common.registry.GameRegistry;
 
 import forestry.api.genetics.ISpeciesRoot;
 
@@ -39,7 +40,7 @@ public interface IBackpackInterface {
 	 * @param itemStack   The itemStack that the backpack should accept.
 	 *                    {@link OreDictionary#WILDCARD_VALUE} can be used for meta value.
 	 */
-	void addItemToForestryBackpack(String backpackUid, ItemStack itemStack);
+	void addItemToForestryBackpack(String backpackUid, @Nullable ItemStack itemStack);
 
 	/**
 	 * Register a backpack definition with a given uid.

--- a/src/main/java/forestry/api/storage/ICrateRegistry.java
+++ b/src/main/java/forestry/api/storage/ICrateRegistry.java
@@ -5,6 +5,8 @@
  ******************************************************************************/
 package forestry.api.storage;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -23,7 +25,7 @@ public interface ICrateRegistry {
 
 	void registerCrate(Block block);
 
-	void registerCrate(ItemStack stack);
+	void registerCrate(@Nullable ItemStack stack);
 
 	void registerCrate(String oreDictName);
 

--- a/src/main/java/forestry/storage/BackpackInterface.java
+++ b/src/main/java/forestry/storage/BackpackInterface.java
@@ -42,9 +42,11 @@ public class BackpackInterface implements IBackpackInterface {
 	}
 
 	@Override
-	public void addItemToForestryBackpack(String backpackUid, ItemStack itemStack) {
+	public void addItemToForestryBackpack(String backpackUid, @Nullable ItemStack itemStack) {
+		if (itemStack == null) {
+			return;
+		}
 		Preconditions.checkNotNull(backpackUid, "backpackUid must not be null");
-		Preconditions.checkNotNull(itemStack, "itemStack must not be null");
 		Preconditions.checkArgument(!itemStack.isEmpty(), "itemStack must not be empty");
 
 		String stringForItemStack = ItemStackUtil.getStringForItemStack(itemStack);

--- a/src/main/java/forestry/storage/CrateRegistry.java
+++ b/src/main/java/forestry/storage/CrateRegistry.java
@@ -72,17 +72,26 @@ public class CrateRegistry implements ICrateRegistry {
 	}
 
 	@Override
-	public void registerCrate(Block block) {
+	public void registerCrate(@Nullable Block block) {
+		if (block == null) {
+			return;
+		}
 		registerCrate(new ItemStack(block), null);
 	}
 
 	@Override
-	public void registerCrate(Item item) {
+	public void registerCrate(@Nullable Item item) {
+		if (item == null) {
+			return;
+		}
 		registerCrate(new ItemStack(item), null);
 	}
 
 	@Override
-	public void registerCrate(ItemStack stack) {
+	public void registerCrate(@Nullable ItemStack stack) {
+		if (stack == null) {
+			return;
+		}
 		registerCrate(stack, null);
 	}
 }


### PR DESCRIPTION
I'm splitting up https://github.com/ForestryMC/ForestryMC/pull/2024 to make it easier to review (I hope). This PR doesn't add much but I think it's cleaner to check for `null` objects inside the methods rather than before registering them, at least for plugins. It also reduces the chances of a crash because an item/block is null for some reason. I could add a log warning if we're worried about things silently failing.