### PR TITLE
Optimise Worldgen Hives

### DIFF
--- a/src/main/java/forestry/apiculture/BeekeepingLogic.java
+++ b/src/main/java/forestry/apiculture/BeekeepingLogic.java
@@ -56,6 +56,7 @@ import forestry.core.config.Constants;
 import forestry.core.errors.EnumErrorCode;
 import forestry.core.utils.Log;
 import forestry.core.utils.NetworkUtil;
+import forestry.core.utils.TickHelper;
 
 public class BeekeepingLogic implements IBeekeepingLogic {
 
@@ -76,6 +77,7 @@ public class BeekeepingLogic implements IBeekeepingLogic {
 	private final HasFlowersCache hasFlowersCache = new HasFlowersCache();
 	private final QueenCanWorkCache queenCanWorkCache = new QueenCanWorkCache();
 	private final PollenHandler pollenHandler = new PollenHandler();
+	private final TickHelper tickHelper = new TickHelper();
 
 	// Client
 	private boolean active;
@@ -226,8 +228,10 @@ public class BeekeepingLogic implements IBeekeepingLogic {
 		for (IErrorState errorState : queenErrors) {
 			errorLogic.setCondition(true, errorState);
 		}
-
-		hasFlowersCache.update(queen, housing);
+		tickHelper.onTick();
+		if (tickHelper.updateOnInterval(100)) {
+			hasFlowersCache.update(queen, housing);
+		}
 		boolean hasFlowers = hasFlowersCache.hasFlowers();
 		boolean flowerCacheNeedsSync = hasFlowersCache.needsSync();
 		errorLogic.setCondition(!hasFlowers, EnumErrorCode.NO_FLOWER);

--- a/src/main/java/forestry/apiculture/BeekeepingLogic.java
+++ b/src/main/java/forestry/apiculture/BeekeepingLogic.java
@@ -56,7 +56,6 @@ import forestry.core.config.Constants;
 import forestry.core.errors.EnumErrorCode;
 import forestry.core.utils.Log;
 import forestry.core.utils.NetworkUtil;
-import forestry.core.utils.TickHelper;
 
 public class BeekeepingLogic implements IBeekeepingLogic {
 
@@ -77,7 +76,6 @@ public class BeekeepingLogic implements IBeekeepingLogic {
 	private final HasFlowersCache hasFlowersCache = new HasFlowersCache();
 	private final QueenCanWorkCache queenCanWorkCache = new QueenCanWorkCache();
 	private final PollenHandler pollenHandler = new PollenHandler();
-	private final TickHelper tickHelper = new TickHelper();
 
 	// Client
 	private boolean active;
@@ -228,10 +226,9 @@ public class BeekeepingLogic implements IBeekeepingLogic {
 		for (IErrorState errorState : queenErrors) {
 			errorLogic.setCondition(true, errorState);
 		}
-		tickHelper.onTick();
-		if (tickHelper.updateOnInterval(100)) {
-			hasFlowersCache.update(queen, housing);
-		}
+
+		hasFlowersCache.update(queen, housing);
+
 		boolean hasFlowers = hasFlowersCache.hasFlowers();
 		boolean flowerCacheNeedsSync = hasFlowersCache.needsSync();
 		errorLogic.setCondition(!hasFlowers, EnumErrorCode.NO_FLOWER);

--- a/src/main/java/forestry/apiculture/HasFlowersCache.java
+++ b/src/main/java/forestry/apiculture/HasFlowersCache.java
@@ -118,7 +118,7 @@ public class HasFlowersCache implements INbtWritable, INbtReadable {
 			IBeeGenome genome = queen.getGenome();
 			String flowerType = genome.getFlowerProvider().getFlowerType();
 			if (!this.flowerData.flowerType.equals(flowerType)
-				|| !this.flowerData.territory.equals(genome.getTerritory())) {
+					|| !this.flowerData.territory.equals(genome.getTerritory())) {
 				flowerData = new FlowerData(queen, housing);
 				flowerCoords.clear();
 				flowers.clear();

--- a/src/main/java/forestry/apiculture/HasFlowersCache.java
+++ b/src/main/java/forestry/apiculture/HasFlowersCache.java
@@ -37,7 +37,7 @@ import forestry.core.utils.TickHelper;
 public class HasFlowersCache implements INbtWritable, INbtReadable {
 	private static final String NBT_KEY = "hasFlowerCache";
 	private static final String NBT_KEY_FLOWERS = "flowers";
-	private static final int FLOWER_CHECK_INTERVAL = 200;
+	private static final int FLOWER_CHECK_INTERVAL = 2;
 
 	private final TickHelper tickHelper = new TickHelper();
 

--- a/src/main/java/forestry/apiculture/HasFlowersCache.java
+++ b/src/main/java/forestry/apiculture/HasFlowersCache.java
@@ -37,9 +37,17 @@ import forestry.core.utils.TickHelper;
 public class HasFlowersCache implements INbtWritable, INbtReadable {
 	private static final String NBT_KEY = "hasFlowerCache";
 	private static final String NBT_KEY_FLOWERS = "flowers";
-	private static final int FLOWER_CHECK_INTERVAL = 2;
+	private int flowerCheckInterval;
 
 	private final TickHelper tickHelper = new TickHelper();
+
+	public HasFlowersCache() {
+		this.flowerCheckInterval = 200;
+	}
+	
+	public HasFlowersCache(int checkInterval) {
+		flowerCheckInterval = checkInterval;
+	}
 
 	@Nullable
 	private FlowerData flowerData;
@@ -76,7 +84,7 @@ public class HasFlowersCache implements INbtWritable, INbtReadable {
 		World world = beeHousing.getWorldObj();
 		tickHelper.onTick();
 
-		if (!flowerCoords.isEmpty() && tickHelper.updateOnInterval(FLOWER_CHECK_INTERVAL)) {
+		if (!flowerCoords.isEmpty() && tickHelper.updateOnInterval(flowerCheckInterval)) {
 			Iterator<BlockPos> iterator = flowerCoords.iterator();
 			while (iterator.hasNext()) {
 				BlockPos flowerPos = iterator.next();

--- a/src/main/java/forestry/apiculture/WorldgenBeekeepingLogic.java
+++ b/src/main/java/forestry/apiculture/WorldgenBeekeepingLogic.java
@@ -33,6 +33,7 @@ import forestry.core.utils.TickHelper;
 
 public class WorldgenBeekeepingLogic implements IBeekeepingLogic {
 	private final TileHive housing;
+	private IBee queen;
 	private IEffectData effectData[] = new IEffectData[2];
 	private final HasFlowersCache hasFlowersCache = new HasFlowersCache();
 	private final TickHelper tickHelper = new TickHelper();
@@ -92,10 +93,11 @@ public class WorldgenBeekeepingLogic implements IBeekeepingLogic {
 	public boolean canWork() {
 		tickHelper.onTick();
 
-		IBee queen = housing.getContainedBee();
-		hasFlowersCache.update(queen, housing);
-
 		if (tickHelper.updateOnInterval(200)) {
+			if (queen == null) {                //Trying to set this in constructor causes crash
+				queen = housing.getContainedBee();
+			}
+			hasFlowersCache.update(queen, housing);
 			World world = housing.getWorldObj();
 			boolean canWork = (world.isDaytime() || queen.getGenome().getNeverSleeps()) &&
 					(!housing.isRaining() || queen.getGenome().getToleratesRain());

--- a/src/main/java/forestry/apiculture/WorldgenBeekeepingLogic.java
+++ b/src/main/java/forestry/apiculture/WorldgenBeekeepingLogic.java
@@ -35,7 +35,7 @@ public class WorldgenBeekeepingLogic implements IBeekeepingLogic {
 	private final TileHive housing;
 	private IBee queen;
 	private IEffectData effectData[] = new IEffectData[2];
-	private final HasFlowersCache hasFlowersCache = new HasFlowersCache();
+	private final HasFlowersCache hasFlowersCache = new HasFlowersCache(2);
 	private final TickHelper tickHelper = new TickHelper();
 
 	// Client


### PR DESCRIPTION
Possibly I'm misunderstanding something here. However, I think some things can be moved in `WorldgenBeekeepingLogic` to further optimise worldgen hives.

- As far as I'm aware the queen in these hives doesn't change so it can be stored as a field
- I don't think the flower cache needs to be updated if we're not checking whether the bee can work or not. So it can be updated less often.

Could help for https://github.com/ForestryMC/ForestryMC/issues/2060.