### PR TITLE
Small JEI fix

### DIFF
--- a/src/main/java/forestry/apiculture/compat/ApicultureJeiPlugin.java
+++ b/src/main/java/forestry/apiculture/compat/ApicultureJeiPlugin.java
@@ -2,17 +2,14 @@ package forestry.apiculture.compat;
 
 import com.google.common.base.Preconditions;
 
-import net.minecraft.util.ResourceLocation;
-
 import forestry.api.apiculture.BeeManager;
-import forestry.api.core.ForestryAPI;
 import forestry.api.genetics.IAlleleSpecies;
 import forestry.apiculture.ModuleApiculture;
 import forestry.apiculture.items.ItemRegistryApiculture;
-import forestry.core.config.Constants;
 import forestry.core.genetics.Genome;
 import forestry.core.utils.JeiUtil;
 import forestry.modules.ForestryModuleUids;
+import forestry.modules.ModuleHelper;
 
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
@@ -23,7 +20,7 @@ import mezz.jei.api.JEIPlugin;
 public class ApicultureJeiPlugin implements IModPlugin {
 	@Override
 	public void registerItemSubtypes(ISubtypeRegistry subtypeRegistry) {
-		if (!ForestryAPI.enabledModules.contains(new ResourceLocation(Constants.MOD_ID, ForestryModuleUids.APICULTURE))) {
+		if (!ModuleHelper.isEnabled(ForestryModuleUids.APICULTURE)) {
 			return;
 		}
 
@@ -42,7 +39,7 @@ public class ApicultureJeiPlugin implements IModPlugin {
 
 	@Override
 	public void register(IModRegistry registry) {
-		if (!ForestryAPI.enabledModules.contains(new ResourceLocation(Constants.MOD_ID, ForestryModuleUids.APICULTURE))) {
+		if (!ModuleHelper.isEnabled(ForestryModuleUids.APICULTURE)) {
 			return;
 		}
 

--- a/src/main/java/forestry/arboriculture/compat/ArboricultureJeiPlugin.java
+++ b/src/main/java/forestry/arboriculture/compat/ArboricultureJeiPlugin.java
@@ -10,6 +10,7 @@ import forestry.arboriculture.items.ItemRegistryArboriculture;
 import forestry.core.config.Constants;
 import forestry.core.utils.JeiUtil;
 import forestry.modules.ForestryModuleUids;
+import forestry.modules.ModuleHelper;
 
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
@@ -19,7 +20,7 @@ import mezz.jei.api.JEIPlugin;
 public class ArboricultureJeiPlugin implements IModPlugin {
 	@Override
 	public void register(IModRegistry registry) {
-		if (!ForestryAPI.enabledModules.contains(new ResourceLocation(Constants.MOD_ID, ForestryModuleUids.ARBORICULTURE))) {
+		if (!ModuleHelper.isEnabled(ForestryModuleUids.ARBORICULTURE)) {
 			return;
 		}
 

--- a/src/main/java/forestry/mail/compat/MailJeiPlugin.java
+++ b/src/main/java/forestry/mail/compat/MailJeiPlugin.java
@@ -1,13 +1,10 @@
 package forestry.mail.compat;
 
-import net.minecraft.util.ResourceLocation;
-
-import forestry.api.core.ForestryAPI;
-import forestry.core.config.Constants;
 import forestry.core.utils.JeiUtil;
 import forestry.mail.ModuleMail;
 import forestry.mail.blocks.BlockRegistryMail;
 import forestry.modules.ForestryModuleUids;
+import forestry.modules.ModuleHelper;
 
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
@@ -17,7 +14,7 @@ import mezz.jei.api.JEIPlugin;
 public class MailJeiPlugin implements IModPlugin {
 	@Override
 	public void register(IModRegistry registry) {
-		if (!ForestryAPI.enabledModules.contains(new ResourceLocation(Constants.MOD_ID, ForestryModuleUids.MAIL))) {
+		if (!ModuleHelper.isEnabled(ForestryModuleUids.MAIL)) {
 			return;
 		}
 

--- a/src/main/java/forestry/storage/compat/StorageJeiPlugin.java
+++ b/src/main/java/forestry/storage/compat/StorageJeiPlugin.java
@@ -1,11 +1,8 @@
 package forestry.storage.compat;
 
-import net.minecraft.util.ResourceLocation;
-
-import forestry.api.core.ForestryAPI;
-import forestry.core.config.Constants;
 import forestry.core.utils.JeiUtil;
 import forestry.modules.ForestryModuleUids;
+import forestry.modules.ModuleHelper;
 import forestry.storage.ModuleBackpacks;
 import forestry.storage.items.ItemRegistryBackpacks;
 
@@ -17,7 +14,7 @@ import mezz.jei.api.JEIPlugin;
 public class StorageJeiPlugin implements IModPlugin {
 	@Override
 	public void register(IModRegistry registry) {
-		if (!ForestryAPI.enabledModules.contains(new ResourceLocation(Constants.MOD_ID, ForestryModuleUids.BACKPACKS))) {
+		if (!ModuleHelper.isEnabled(ForestryModuleUids.BACKPACKS)) {
 			return;
 		}
 
@@ -47,9 +44,11 @@ public class StorageJeiPlugin implements IModPlugin {
 				items.builderBackpack,
 				items.builderBackpackT2
 		);
-		JeiUtil.addDescription(registry,
-				items.apiaristBackpack,
-				items.lepidopteristBackpack
-		);
+		if (ModuleHelper.isEnabled(ForestryModuleUids.APICULTURE)) {
+			JeiUtil.addDescription(registry, items.apiaristBackpack);
+		}
+		if (ModuleHelper.isEnabled(ForestryModuleUids.LEPIDOPTEROLOGY)) {
+			JeiUtil.addDescription(registry, items.lepidopteristBackpack);
+		}
 	}
 }

--- a/src/main/java/forestry/worktable/compat/WorktableJeiPlugin.java
+++ b/src/main/java/forestry/worktable/compat/WorktableJeiPlugin.java
@@ -25,7 +25,7 @@ public class WorktableJeiPlugin implements IModPlugin {
 
 	@Override
 	public void register(IModRegistry registry) {
-		if(!ModuleHelper.isEnabled(ForestryModuleUids.WORKTABLE)){
+		if (!ModuleHelper.isEnabled(ForestryModuleUids.WORKTABLE)) {
 			return;
 		}
 		BlockRegistryWorktable blocks = ModuleWorktable.getBlocks();


### PR DESCRIPTION
I missed an edge case in https://github.com/ForestryMC/ForestryMC/pull/2033.

If Apiculture/Lepidopterology are disabled and Storage isn't then the log will have the error:
```[01:57:33] [main/ERROR]: Failed to register mod plugin: class forestry.storage.compat.StorageJeiPlugin
java.lang.NullPointerException: null
	at forestry.core.utils.JeiUtil.addDescription(JeiUtil.java:43) ~[JeiUtil.class:?]
	at forestry.core.utils.JeiUtil.addDescription(JeiUtil.java:38) ~[JeiUtil.class:?]
        ...
```

This fixes that and moves things to use `ModuleHelper`.