### PR TITLE
fix bottler dupe

### DIFF
--- a/src/main/java/forestry/core/fluids/FluidHelper.java
+++ b/src/main/java/forestry/core/fluids/FluidHelper.java
@@ -74,10 +74,10 @@ public final class FluidHelper {
 		ItemStack filled = input.copy();
 		filled.setCount(1);
 
-		if(emptyStack.isEmpty()){
+		if (emptyStack.isEmpty()) {
 			emptyStack = filled;
 		}
-		
+
 		IFluidHandlerItem fluidFilledHandler = FluidUtil.getFluidHandler(filled);
 		IFluidHandlerItem fluidEmptyHandler = FluidUtil.getFluidHandler(emptyStack);
 		if (fluidFilledHandler == null || fluidEmptyHandler == null) {
@@ -190,8 +190,8 @@ public final class FluidHelper {
 							inv.setInventorySlotContents(outputSlot, newStack);
 							inv.decrStackSize(inputSlot, 1);
 						}
-						if(!isFillableEmptyContainer(newStack) && isFillableContainerWithRoom(newStack)) {
-							inv.setInventorySlotContents(inputSlot, newStack.copy());
+						if (isDrainableContainer(newStack) && !isEmpty(newStack)) {
+							inv.setInventorySlotContents(inputSlot, newStack);
 						}
 					} else {
 						inv.decrStackSize(inputSlot, 1);
@@ -311,6 +311,39 @@ public final class FluidHelper {
 
 			FluidStack contents = properties.getContents();
 			if (contents == null || contents.amount < properties.getCapacity()) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	public static boolean isDrainableContainer(ItemStack container) {
+		IFluidHandler fluidHandler = FluidUtil.getFluidHandler(container);
+		if (fluidHandler == null) {
+			return false;
+		}
+
+		IFluidTankProperties[] tankProperties = fluidHandler.getTankProperties();
+		for (IFluidTankProperties properties : tankProperties) {
+			if (properties.canDrain()) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static boolean isEmpty(ItemStack container) {
+		IFluidHandler fluidHandler = FluidUtil.getFluidHandler(container);
+		if (fluidHandler == null) {
+			return false;
+		}
+
+		IFluidTankProperties[] tankProperties = fluidHandler.getTankProperties();
+		for (IFluidTankProperties properties : tankProperties) {
+			FluidStack contents = properties.getContents();
+			if (contents != null && contents.amount > 0) {
 				return false;
 			}
 		}

--- a/src/main/java/forestry/core/fluids/FluidHelper.java
+++ b/src/main/java/forestry/core/fluids/FluidHelper.java
@@ -190,6 +190,9 @@ public final class FluidHelper {
 							inv.setInventorySlotContents(outputSlot, newStack);
 							inv.decrStackSize(inputSlot, 1);
 						}
+						if(!isFillableEmptyContainer(newStack) && isFillableContainerWithRoom(newStack)) {
+							inv.setInventorySlotContents(inputSlot, newStack.copy());
+						}
 					} else {
 						inv.decrStackSize(inputSlot, 1);
 					}
@@ -314,4 +317,5 @@ public final class FluidHelper {
 
 		return true;
 	}
+
 }


### PR DESCRIPTION
Closes https://github.com/ForestryMC/ForestryMC/issues/2126. The new behaviour will keep the stack in the emptying slot until it is completely empty but also decrease the fluid amount in it. Maybe that's not the correct way for it to work. I also ran into a weird bug where it seemed the bottler operation took longer for bigger tanks. Maybe that's intentional.

If there's a better way to fix this just ignore this one :smile: .