### PR TITLE
Update maven used for tesla

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,6 @@ minecraft {
 
 repositories {
 	maven {
-		url 'http://maven.epoxide.xyz'
-	}
-	maven {
 		url "http://dvs1.progwml6.com/files/maven"
 	}
 	maven {
@@ -53,6 +50,10 @@ repositories {
 	maven {
 		name = "Modmuss50"
 		url = "http://maven.modmuss50.me"
+	}
+	maven {
+
+		url 'http://maven.mcmoddev.com'
 	}
 }
 


### PR DESCRIPTION
Fixes issues with gradle tasks failing due to not being able to find tesla.

http://maven.epoxide.xyz/ doesn't host anything anymore it seems. https://maven.mcmoddev.com/ has the same structure and is linked to on  the tesla github page so I assume that's the correct one to use.