### PR TITLE
Fix Tile Entity Registration names

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 mcversion=1.12.2
-forgeversion=14.23.2.2643
+forgeversion=14.23.4.2705
 mcp_mappings=snapshot_20171003
 curse_project_id=59751
 

--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -68,7 +68,7 @@ import forestry.plugins.PluginTechReborn;
 		version = Constants.VERSION,
 		guiFactory = "forestry.core.config.ForestryGuiConfigFactory",
 		acceptedMinecraftVersions = "[1.12.2,1.13.0)",
-		dependencies = "required-after:forge@[14.23.2.2643,);"
+		dependencies = "required-after:forge@[14.23.4.2705,);"
 				+ "after:jei@[4.7.8.91,);"
 				+ "after:" + PluginIC2.MOD_ID + ";"
 				+ "after:" + PluginNatura.MOD_ID + ";"

--- a/src/main/java/forestry/apiculture/ModuleApiculture.java
+++ b/src/main/java/forestry/apiculture/ModuleApiculture.java
@@ -302,15 +302,15 @@ public class ModuleApiculture extends BlankForestryModule {
 		// Inducers for swarmer
 		BeeManager.inducers.put(items.royalJelly.getItemStack(), 10);
 
-		GameRegistry.registerTileEntity(TileAlvearyPlain.class, "forestry.Alveary");
-		GameRegistry.registerTileEntity(TileHive.class, "forestry.Swarm");
-		GameRegistry.registerTileEntity(TileAlvearySwarmer.class, "forestry.AlvearySwarmer");
-		GameRegistry.registerTileEntity(TileAlvearyHeater.class, "forestry.AlvearyHeater");
-		GameRegistry.registerTileEntity(TileAlvearyFan.class, "forestry.AlvearyFan");
-		GameRegistry.registerTileEntity(TileAlvearyHygroregulator.class, "forestry.AlvearyHygro");
-		GameRegistry.registerTileEntity(TileAlvearyStabiliser.class, "forestry.AlvearyStabiliser");
-		GameRegistry.registerTileEntity(TileAlvearySieve.class, "forestry.AlvearySieve");
-		GameRegistry.registerTileEntity(TileCandle.class, "forestry.Candle");
+		GameRegistry.registerTileEntity(TileAlvearyPlain.class, new ResourceLocation(Constants.MOD_ID, "alveary"));
+		GameRegistry.registerTileEntity(TileHive.class, new ResourceLocation(Constants.MOD_ID, "swarm"));
+		GameRegistry.registerTileEntity(TileAlvearySwarmer.class, new ResourceLocation(Constants.MOD_ID, "alvearySwarmer"));
+		GameRegistry.registerTileEntity(TileAlvearyHeater.class, new ResourceLocation(Constants.MOD_ID, "alvearyHeater"));
+		GameRegistry.registerTileEntity(TileAlvearyFan.class, new ResourceLocation(Constants.MOD_ID, "alvearyFan"));
+		GameRegistry.registerTileEntity(TileAlvearyHygroregulator.class, new ResourceLocation(Constants.MOD_ID, "alvearyHygro"));
+		GameRegistry.registerTileEntity(TileAlvearyStabiliser.class, new ResourceLocation(Constants.MOD_ID, "alvearyStabiliser"));
+		GameRegistry.registerTileEntity(TileAlvearySieve.class, new ResourceLocation(Constants.MOD_ID, "alvearySieve"));
+		GameRegistry.registerTileEntity(TileCandle.class, new ResourceLocation(Constants.MOD_ID, "candle"));
 
 		ResourceLocation beeHouseCartResource = new ResourceLocation(Constants.MOD_ID, "cart.beehouse");
 		EntityUtil.registerEntity(beeHouseCartResource, EntityMinecartBeehouse.class, "cart.beehouse", 1, 0x000000, 0xffffff, 256, 3, true);

--- a/src/main/java/forestry/arboriculture/ModuleArboriculture.java
+++ b/src/main/java/forestry/arboriculture/ModuleArboriculture.java
@@ -177,7 +177,7 @@ public class ModuleArboriculture extends BlankForestryModule {
 	@Override
 	public void preInit() {
 		MinecraftForge.EVENT_BUS.register(this);
-		
+
 		if (Config.generateTrees) {
 			MinecraftForge.TERRAIN_GEN_BUS.register(new TreeDecorator());
 		}
@@ -214,7 +214,7 @@ public class ModuleArboriculture extends BlankForestryModule {
 		// Commands
 		ModuleCore.rootCommand.addChildCommand(new CommandTree());
 
-		if(ModuleHelper.isEnabled( ForestryModuleUids.SORTING)){
+		if (ModuleHelper.isEnabled(ForestryModuleUids.SORTING)) {
 			ArboricultureFilterRuleType.init();
 		}
 	}
@@ -231,9 +231,9 @@ public class ModuleArboriculture extends BlankForestryModule {
 		TreeDefinition.initTrees();
 		registerErsatzGenomes();
 
-		GameRegistry.registerTileEntity(TileSapling.class, "forestry.Sapling");
-		GameRegistry.registerTileEntity(TileLeaves.class, "forestry.Leaves");
-		GameRegistry.registerTileEntity(TileFruitPod.class, "forestry.Pods");
+		GameRegistry.registerTileEntity(TileSapling.class, new ResourceLocation(Constants.MOD_ID, "sapling"));
+		GameRegistry.registerTileEntity(TileLeaves.class, new ResourceLocation(Constants.MOD_ID, "leaves"));
+		GameRegistry.registerTileEntity(TileFruitPod.class, new ResourceLocation(Constants.MOD_ID, "pods"));
 
 		ItemRegistryArboriculture items = getItems();
 		BlockRegistryArboriculture blocks = getBlocks();
@@ -425,7 +425,7 @@ public class ModuleArboriculture extends BlankForestryModule {
 			RecipeManagers.squeezerManager.addRecipe(10, EnumFruit.PLUM.getStack(), Fluids.JUICE.getFluid((int) Math.floor(juiceMultiplier * 0.5f)), mulch, mulchMultiplier * 3);
 			RecipeManagers.squeezerManager.addRecipe(10, EnumFruit.PAPAYA.getStack(), Fluids.JUICE.getFluid(juiceMultiplier * 3), mulch, (int) Math.floor(mulchMultiplier * 0.5f));
 			RecipeManagers.squeezerManager.addRecipe(10, EnumFruit.DATES.getStack(), Fluids.JUICE.getFluid((int) Math.floor(juiceMultiplier * 0.25)), mulch, mulchMultiplier);
-			
+
 			RecipeUtil.addFermenterRecipes(new ItemStack(items.sapling, 1, OreDictionary.WILDCARD_VALUE), ForestryAPI.activeMode.getIntegerSetting("fermenter.yield.sapling"), Fluids.BIOMASS);
 		}
 
@@ -541,7 +541,7 @@ public class ModuleArboriculture extends BlankForestryModule {
 			return true;
 		} else if (message.key.equals("blacklist-trees-dimension")) {
 			int[] dims = message.getNBTValue().getIntArray("dimensions");
-			for(int dim : dims) {
+			for (int dim : dims) {
 				Config.blacklistTreeDim(dim);
 			}
 			return true;

--- a/src/main/java/forestry/core/ModuleCore.java
+++ b/src/main/java/forestry/core/ModuleCore.java
@@ -71,6 +71,7 @@ import forestry.core.owner.GameProfileDataSerializer;
 import forestry.core.proxy.Proxies;
 import forestry.core.recipes.RecipeUtil;
 import forestry.core.render.TextureManagerForestry;
+import forestry.core.tiles.TileEntityDataFixer;
 import forestry.core.utils.ClimateUtil;
 import forestry.core.utils.ForestryModEnvWarningCallable;
 import forestry.core.utils.OreDictUtil;
@@ -142,6 +143,8 @@ public class ModuleCore extends BlankForestryModule {
 		MinecraftForge.EVENT_BUS.register(World2ObjectMap.class);
 
 		rootCommand.addChildCommand(new CommandModules());
+
+		new TileEntityDataFixer();
 	}
 
 	@Override
@@ -288,7 +291,7 @@ public class ModuleCore extends BlankForestryModule {
 
 		// / WRENCH
 		RecipeUtil.addRecipe("wrench", items.wrench, "# #", " # ", " # ", '#', OreDictUtil.INGOT_BRONZE);
-		
+
 		// / WEB
 		RecipeUtil.addRecipe("silk_wisp_to_web", new ItemStack(Blocks.WEB, 4), "# #", " # ", "# #", '#', items.craftingMaterial.getSilkWisp());
 
@@ -433,22 +436,22 @@ public class ModuleCore extends BlankForestryModule {
 			RecipeUtil.addShapelessRecipe("block_to_bronze", ingotBronze, OreDictUtil.BLOCK_BRONZE);
 		}
 
-		if(!ModuleHelper.isEnabled(ForestryModuleUids.CHARCOAL)){
+		if (!ModuleHelper.isEnabled(ForestryModuleUids.CHARCOAL)) {
 			RecipeUtil.addSmelting(new ItemStack(items.ash, 2), new ItemStack(Items.COAL, 1, 1), 0.15F);
 		}
 
 		RecipeUtil.addRecipe("ash_brick", blocks.ashBrick,
-			"A#A",
-			"# #",
-			"A#A",
-			'#', Items.BRICK,
-			'A', OreDictUtil.DUST_ASH);
+				"A#A",
+				"# #",
+				"A#A",
+				'#', Items.BRICK,
+				'A', OreDictUtil.DUST_ASH);
 		RecipeUtil.addRecipe("ash_stairs", blocks.ashStairs,
-			true,
-			"#  ",
-			"## ",
-			"###",
-			'#', Items.BRICK);
+				true,
+				"#  ",
+				"## ",
+				"###",
+				'#', Items.BRICK);
 
 		// alternate recipes
 		if (!ModuleHelper.isEnabled(ForestryModuleUids.APICULTURE)) {
@@ -467,14 +470,14 @@ public class ModuleCore extends BlankForestryModule {
 	public boolean processIMCMessage(IMCMessage message) {
 		if (message.key.equals("blacklist-ores-dimension")) {
 			int[] dims = message.getNBTValue().getIntArray("dimensions");
-			for(int dim : dims) {
+			for (int dim : dims) {
 				Config.blacklistOreDim(dim);
 			}
 			return true;
 		}
 		return false;
 	}
-	
+
 	@Override
 	public IPickupHandler getPickupHandler() {
 		return new PickupHandlerCore();

--- a/src/main/java/forestry/core/blocks/MachineProperties.java
+++ b/src/main/java/forestry/core/blocks/MachineProperties.java
@@ -1,12 +1,9 @@
 package forestry.core.blocks;
 
+import com.google.common.base.Preconditions;
+
 import javax.annotation.Nullable;
 
-import com.google.common.base.Preconditions;
-import forestry.api.core.IModelManager;
-import forestry.core.tiles.TileForestry;
-import forestry.core.utils.BlockUtil;
-import forestry.core.utils.ItemStackUtil;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.Item;
@@ -17,9 +14,16 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import forestry.api.core.IModelManager;
+import forestry.core.config.Constants;
+import forestry.core.tiles.TileForestry;
+import forestry.core.utils.BlockUtil;
+import forestry.core.utils.ItemStackUtil;
 
 public class MachineProperties<T extends TileForestry> implements IMachineProperties<T> {
 	private final String name;
@@ -30,11 +34,11 @@ public class MachineProperties<T extends TileForestry> implements IMachineProper
 	private Block block;
 
 	public MachineProperties(Class<T> teClass, String name) {
-		this("forestry." + name, teClass, name, new AxisAlignedBB(0, 0, 0, 1, 1, 1));
+		this(name, teClass, name, new AxisAlignedBB(0, 0, 0, 1, 1, 1));
 	}
 
 	public MachineProperties(Class<T> teClass, String name, AxisAlignedBB boundingBox) {
-		this("forestry." + name, teClass, name, boundingBox);
+		this(name, teClass, name, boundingBox);
 	}
 
 	private MachineProperties(String teIdent, Class<T> teClass, String name, AxisAlignedBB boundingBox) {
@@ -68,7 +72,7 @@ public class MachineProperties<T extends TileForestry> implements IMachineProper
 
 	@Override
 	public void registerTileEntity() {
-		GameRegistry.registerTileEntity(teClass, teIdent);
+		GameRegistry.registerTileEntity(teClass, new ResourceLocation(Constants.MOD_ID, name));
 	}
 
 	@Override

--- a/src/main/java/forestry/core/blocks/MachineProperties.java
+++ b/src/main/java/forestry/core/blocks/MachineProperties.java
@@ -27,22 +27,16 @@ import forestry.core.utils.ItemStackUtil;
 
 public class MachineProperties<T extends TileForestry> implements IMachineProperties<T> {
 	private final String name;
-	private final String teIdent;
 	private final Class<T> teClass;
 	private final AxisAlignedBB boundingBox;
 	@Nullable
 	private Block block;
 
 	public MachineProperties(Class<T> teClass, String name) {
-		this(name, teClass, name, new AxisAlignedBB(0, 0, 0, 1, 1, 1));
+		this(teClass, name, new AxisAlignedBB(0, 0, 0, 1, 1, 1));
 	}
 
 	public MachineProperties(Class<T> teClass, String name, AxisAlignedBB boundingBox) {
-		this(name, teClass, name, boundingBox);
-	}
-
-	private MachineProperties(String teIdent, Class<T> teClass, String name, AxisAlignedBB boundingBox) {
-		this.teIdent = teIdent;
 		this.teClass = teClass;
 		this.name = name;
 		this.boundingBox = boundingBox;

--- a/src/main/java/forestry/core/tiles/TileEntityDataFixer.java
+++ b/src/main/java/forestry/core/tiles/TileEntityDataFixer.java
@@ -1,0 +1,44 @@
+package forestry.core.tiles;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.datafix.FixTypes;
+import net.minecraft.util.datafix.IFixableData;
+
+import net.minecraftforge.common.util.CompoundDataFixer;
+import net.minecraftforge.common.util.ModFixs;
+
+import net.minecraftforge.fml.common.FMLCommonHandler;
+
+import forestry.core.config.Constants;
+
+public class TileEntityDataFixer {
+	//id tag is the name.
+	private CompoundDataFixer fixer;
+	private ModFixs modFixs;
+	private Fixable fixable;
+
+	public TileEntityDataFixer() {
+		fixable = new Fixable();
+		fixer = FMLCommonHandler.instance().getDataFixer();
+		modFixs = fixer.init(Constants.MOD_ID, fixable.getFixVersion());    //is there a current save format version?
+		modFixs.registerFix(FixTypes.BLOCK_ENTITY, fixable);
+	}
+
+	public static class Fixable implements IFixableData {
+
+		@Override
+		public int getFixVersion() {
+			return 1;
+		}
+
+		@Override
+		public NBTTagCompound fixTagCompound(NBTTagCompound compound) {
+			String id = compound.getString("id");
+			if (id.contains("forestry.")) {
+				id = id.replace(".", ":");
+			}
+			compound.setString("id", id);
+			return compound;
+		}
+	}
+}

--- a/src/main/java/forestry/core/tiles/TileEntityDataFixer.java
+++ b/src/main/java/forestry/core/tiles/TileEntityDataFixer.java
@@ -1,5 +1,7 @@
 package forestry.core.tiles;
 
+import org.apache.commons.lang3.text.WordUtils;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.datafix.FixTypes;
 import net.minecraft.util.datafix.IFixableData;
@@ -10,17 +12,14 @@ import net.minecraftforge.common.util.ModFixs;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
 import forestry.core.config.Constants;
+import forestry.core.utils.Log;
 
 public class TileEntityDataFixer {
-	//id tag is the name.
-	private CompoundDataFixer fixer;
-	private ModFixs modFixs;
-	private Fixable fixable;
 
 	public TileEntityDataFixer() {
-		fixable = new Fixable();
-		fixer = FMLCommonHandler.instance().getDataFixer();
-		modFixs = fixer.init(Constants.MOD_ID, fixable.getFixVersion());    //is there a current save format version?
+		Fixable fixable = new Fixable();
+		CompoundDataFixer fixer = FMLCommonHandler.instance().getDataFixer();
+		ModFixs modFixs = fixer.init(Constants.MOD_ID, fixable.getFixVersion());    //is there a current save format version?
 		modFixs.registerFix(FixTypes.BLOCK_ENTITY, fixable);
 	}
 
@@ -33,12 +32,14 @@ public class TileEntityDataFixer {
 
 		@Override
 		public NBTTagCompound fixTagCompound(NBTTagCompound compound) {
-			String id = compound.getString("id");
-			if (id.contains("forestry.")) {
-				String teName = id.split("\\.")[1];
-				id = "forestry:" + teName;
+			String oldName = compound.getString("id");
+			if (oldName.startsWith("forestry.")) {
+				String id = oldName.replace("forestry.", "");
+				WordUtils.uncapitalize(id);
+				id = "forestry:" + id;
+				Log.info("Replaced bad TE name {} with {}", oldName, id);
+				compound.setString("id", id);
 			}
-			compound.setString("id", id);
 			return compound;
 		}
 	}

--- a/src/main/java/forestry/core/tiles/TileEntityDataFixer.java
+++ b/src/main/java/forestry/core/tiles/TileEntityDataFixer.java
@@ -35,7 +35,8 @@ public class TileEntityDataFixer {
 		public NBTTagCompound fixTagCompound(NBTTagCompound compound) {
 			String id = compound.getString("id");
 			if (id.contains("forestry.")) {
-				id = id.replace(".", ":");
+				String teName = id.split("\\.")[1];
+				id = "forestry:" + teName;
 			}
 			compound.setString("id", id);
 			return compound;

--- a/src/main/java/forestry/farming/ModuleFarming.java
+++ b/src/main/java/forestry/farming/ModuleFarming.java
@@ -26,6 +26,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ResourceLocation;
 
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -129,7 +130,7 @@ public class ModuleFarming extends BlankForestryModule {
 
 		MinecraftForge.EVENT_BUS.register(this);
 		IFarmRegistry registry = ForestryAPI.farmRegistry;
-		
+
 		registry.registerFarmables(ForestryFarmIdentifier.ARBOREAL, new FarmableVanillaSapling());
 		if (ModuleHelper.isEnabled(ForestryModuleUids.ARBORICULTURE)) {
 			registry.registerFarmables(ForestryFarmIdentifier.ARBOREAL, new FarmableGE());
@@ -184,11 +185,11 @@ public class ModuleFarming extends BlankForestryModule {
 		FarmRegistry.getInstance().loadConfig(config);
 		config.save();
 
-		GameRegistry.registerTileEntity(TileFarmPlain.class, "forestry.Farm");
-		GameRegistry.registerTileEntity(TileFarmGearbox.class, "forestry.FarmGearbox");
-		GameRegistry.registerTileEntity(TileFarmHatch.class, "forestry.FarmHatch");
-		GameRegistry.registerTileEntity(TileFarmValve.class, "forestry.FarmValve");
-		GameRegistry.registerTileEntity(TileFarmControl.class, "forestry.FarmControl");
+		GameRegistry.registerTileEntity(TileFarmPlain.class, new ResourceLocation(Constants.MOD_ID, "farm"));
+		GameRegistry.registerTileEntity(TileFarmGearbox.class, new ResourceLocation(Constants.MOD_ID, "farmGearbox"));
+		GameRegistry.registerTileEntity(TileFarmHatch.class, new ResourceLocation(Constants.MOD_ID, "farmHatch"));
+		GameRegistry.registerTileEntity(TileFarmValve.class, new ResourceLocation(Constants.MOD_ID, "farmValve"));
+		GameRegistry.registerTileEntity(TileFarmControl.class, new ResourceLocation(Constants.MOD_ID, "farmControl"));
 
 		IFarmRegistry registry = FarmRegistry.getInstance();
 		BlockRegistryCore coreBlocks = ModuleCore.getBlocks();

--- a/src/main/java/forestry/greenhouse/ModuleGreenhouse.java
+++ b/src/main/java/forestry/greenhouse/ModuleGreenhouse.java
@@ -18,6 +18,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 
 import net.minecraftforge.common.MinecraftForge;
 
@@ -132,15 +133,15 @@ public class ModuleGreenhouse extends BlankForestryModule {
 	public void doInit() {
 		IGreenhouseHelper helper = GreenhouseManager.helper;
 
-		GameRegistry.registerTileEntity(TileGreenhousePlain.class, "forestry.GreenhousePlain");
-		GameRegistry.registerTileEntity(TileHygroregulator.class, "forestry.ClimateSourceHygroregulator");
-		GameRegistry.registerTileEntity(TileGreenhouseGearbox.class, "forestry.GreenhouseGearbox");
-		GameRegistry.registerTileEntity(TileGreenhouseControl.class, "forestry.GreenhouseController");
-		GameRegistry.registerTileEntity(TileGreenhouseWindow.class, "forestry.ClimateSourceWindow");
-		GameRegistry.registerTileEntity(TileFan.class, "forestry.GreenhouseFan");
-		GameRegistry.registerTileEntity(TileHeater.class, "forestry.GreenhouseHeater");
-		GameRegistry.registerTileEntity(TileDehumidifier.class, "forestry.GreenhouseDryer");
-		GameRegistry.registerTileEntity(TileHumidifier.class, "forestry.GreenhouseSprinkler");
+		GameRegistry.registerTileEntity(TileGreenhousePlain.class, new ResourceLocation(Constants.MOD_ID, "greenhousePlain"));
+		GameRegistry.registerTileEntity(TileHygroregulator.class, new ResourceLocation(Constants.MOD_ID, "climateSourceHygroregulator"));
+		GameRegistry.registerTileEntity(TileGreenhouseGearbox.class, new ResourceLocation(Constants.MOD_ID, "greenhouseGearbox"));
+		GameRegistry.registerTileEntity(TileGreenhouseControl.class, new ResourceLocation(Constants.MOD_ID, "greenhouseController"));
+		GameRegistry.registerTileEntity(TileGreenhouseWindow.class, new ResourceLocation(Constants.MOD_ID, "climateSourceWindow"));
+		GameRegistry.registerTileEntity(TileFan.class, new ResourceLocation(Constants.MOD_ID, "greenhouseFan"));
+		GameRegistry.registerTileEntity(TileHeater.class, new ResourceLocation(Constants.MOD_ID, "greenhouseHeater"));
+		GameRegistry.registerTileEntity(TileDehumidifier.class, new ResourceLocation(Constants.MOD_ID, "greenhouseDryer"));
+		GameRegistry.registerTileEntity(TileHumidifier.class, new ResourceLocation(Constants.MOD_ID, "greenhouseSprinkler"));
 
 		helper.registerWindowGlass("glass", new ItemStack(Blocks.GLASS), "blocks/glass");
 		for (EnumDyeColor dye : EnumDyeColor.values()) {
@@ -171,86 +172,86 @@ public class ModuleGreenhouse extends BlankForestryModule {
 
 		ItemStack greenhousePlainBlock = new ItemStack(blocks.greenhouseBlock, 2, BlockGreenhouseType.PLAIN.ordinal());
 		RecipeUtil.addRecipe("greenhouse_plain", greenhousePlainBlock.copy(),
-			"#X#",
-			"SIS",
-			'I', OreDictUtil.INGOT_IRON,
-			'S', OreDictUtil.SLAB_WOOD,
-			'X', GreenhouseController.createDefaultCamouflageBlock(),
-			'#', coreItems.craftingMaterial.getCamouflagedPaneling());
+				"#X#",
+				"SIS",
+				'I', OreDictUtil.INGOT_IRON,
+				'S', OreDictUtil.SLAB_WOOD,
+				'X', GreenhouseController.createDefaultCamouflageBlock(),
+				'#', coreItems.craftingMaterial.getCamouflagedPaneling());
 		greenhousePlainBlock.setCount(1);
 
 		RecipeUtil.addRecipe("greenhouse_control", new ItemStack(blocks.greenhouseBlock, 1, BlockGreenhouseType.CONTROL.ordinal()),
-			" X ",
-			"#T#",
-			'X', greenhousePlainBlock.copy(),
-			'#', OreDictUtil.DUST_REDSTONE,
-			'T', coreItems.tubes.get(EnumElectronTube.GOLD, 1));
+				" X ",
+				"#T#",
+				'X', greenhousePlainBlock.copy(),
+				'#', OreDictUtil.DUST_REDSTONE,
+				'T', coreItems.tubes.get(EnumElectronTube.GOLD, 1));
 
 		RecipeUtil.addRecipe("greenhouse_gearbox", new ItemStack(blocks.greenhouseBlock, 1, BlockGreenhouseType.GEARBOX.ordinal()),
-			" X ",
-			"###",
-			'X', greenhousePlainBlock.copy(),
-			'#', OreDictUtil.GEAR_TIN);
+				" X ",
+				"###",
+				'X', greenhousePlainBlock.copy(),
+				'#', OreDictUtil.GEAR_TIN);
 
 		RecipeUtil.addRecipe("greenhouse_hygro", new ItemStack(blocks.climatiserBlock, 1, BlockClimatiserType.HYGRO.ordinal()),
-			"GIG",
-			"GXG",
-			"GIG",
-			'X', greenhousePlainBlock.copy(),
-			'I', OreDictUtil.INGOT_IRON,
-			'G', OreDictUtil.BLOCK_GLASS);
+				"GIG",
+				"GXG",
+				"GIG",
+				'X', greenhousePlainBlock.copy(),
+				'I', OreDictUtil.INGOT_IRON,
+				'G', OreDictUtil.BLOCK_GLASS);
 
 		RecipeUtil.addRecipe("greenhouse_heater", new ItemStack(blocks.climatiserBlock, 1, BlockClimatiserType.HEATER.ordinal()),
-			"T#T",
-			"#X#",
-			"T#T",
-			'X', greenhousePlainBlock.copy(),
-			'#', OreDictUtil.INGOT_TIN,
-			'T', coreItems.tubes.get(EnumElectronTube.GOLD, 1));
+				"T#T",
+				"#X#",
+				"T#T",
+				'X', greenhousePlainBlock.copy(),
+				'#', OreDictUtil.INGOT_TIN,
+				'T', coreItems.tubes.get(EnumElectronTube.GOLD, 1));
 
 		RecipeUtil.addRecipe("greenhouse_fan", new ItemStack(blocks.climatiserBlock, 1, BlockClimatiserType.FAN.ordinal()),
-			"T#T",
-			"#X#",
-			"T#T",
-			'X', greenhousePlainBlock.copy(),
-			'#', OreDictUtil.INGOT_IRON,
-			'T', coreItems.tubes.get(EnumElectronTube.TIN, 1));
+				"T#T",
+				"#X#",
+				"T#T",
+				'X', greenhousePlainBlock.copy(),
+				'#', OreDictUtil.INGOT_IRON,
+				'T', coreItems.tubes.get(EnumElectronTube.TIN, 1));
 
 		RecipeUtil.addRecipe("greenhouse_dehumidifier", new ItemStack(blocks.climatiserBlock, 1, BlockClimatiserType.DEHUMIDIFIER.ordinal()),
-			"T#T",
-			"#X#",
-			"T#T",
-			'X', greenhousePlainBlock.copy(),
-			'#', OreDictUtil.INGOT_TIN,
-			'T', coreItems.tubes.get(EnumElectronTube.BLAZE, 1));
+				"T#T",
+				"#X#",
+				"T#T",
+				'X', greenhousePlainBlock.copy(),
+				'#', OreDictUtil.INGOT_TIN,
+				'T', coreItems.tubes.get(EnumElectronTube.BLAZE, 1));
 
 		RecipeUtil.addRecipe("greenhouse_humidifier", new ItemStack(blocks.climatiserBlock, 1, BlockClimatiserType.HUMIDIFIER.ordinal()),
-			"T#T",
-			"#X#",
-			"T#T",
-			'X', greenhousePlainBlock.copy(),
-			'#', OreDictUtil.INGOT_TIN,
-			'T', coreItems.tubes.get(EnumElectronTube.LAPIS, 1));
+				"T#T",
+				"#X#",
+				"T#T",
+				'X', greenhousePlainBlock.copy(),
+				'#', OreDictUtil.INGOT_TIN,
+				'T', coreItems.tubes.get(EnumElectronTube.LAPIS, 1));
 
 		for (String glassName : GreenhouseManager.helper.getWindowGlasses()) {
 			ItemStack glassItem = GreenhouseManager.helper.getGlassItem(glassName);
 			ItemStack window = blocks.window.getItem(glassName);
 			ItemStack roodWindow = blocks.roofWindow.getItem(glassName);
 			RecipeUtil.addRecipe("greenhouse_window_" + glassName, roodWindow,
-				true,
-				"SGS",
-				"GGG",
-				"GGG",
-				'G', glassItem,
-				'S', OreDictUtil.STICK_WOOD);
+					true,
+					"SGS",
+					"GGG",
+					"GGG",
+					'G', glassItem,
+					'S', OreDictUtil.STICK_WOOD);
 
 			RecipeUtil.addRecipe("greenhouse_window_roof_" + glassName, window,
-				true,
-				"SGG",
-				"GGG",
-				"SGG",
-				'G', glassItem,
-				'S', OreDictUtil.STICK_WOOD);
+					true,
+					"SGG",
+					"GGG",
+					"SGG",
+					'G', glassItem,
+					'S', OreDictUtil.STICK_WOOD);
 		}
 
 		ICircuitLayout layout = ChipsetManager.circuitRegistry.getLayout("forestry.greenhouse.climatiser");

--- a/src/main/java/forestry/lepidopterology/ModuleLepidopterology.java
+++ b/src/main/java/forestry/lepidopterology/ModuleLepidopterology.java
@@ -134,14 +134,14 @@ public class ModuleLepidopterology extends BlankForestryModule {
 		MinecraftForge.EVENT_BUS.register(this);
 		ButterflyBranchDefinition.createAlleles();
 		ButterflyAlleles.registerEffectAlleles();
-		
+
 		ButterflyDefinition.preInit();
 		MothDefinition.preInit();
 		MinecraftForge.EVENT_BUS.post(new AlleleSpeciesRegisterEvent<>(ButterflyManager.butterflyRoot, IAlleleButterflySpecies.class));
 
 		proxy.preInitializeRendering();
 
-		if(ModuleHelper.isEnabled(ForestryModuleUids.SORTING)){
+		if (ModuleHelper.isEnabled(ForestryModuleUids.SORTING)) {
 			LepidopterologyFilterRule.init();
 			LepidopterologyFilterRuleType.init();
 		}
@@ -159,7 +159,7 @@ public class ModuleLepidopterology extends BlankForestryModule {
 	public void doInit() {
 		BlockRegistryLepidopterology blocks = getBlocks();
 
-		GameRegistry.registerTileEntity(TileCocoon.class, "forestry.Cocoon");
+		GameRegistry.registerTileEntity(TileCocoon.class, new ResourceLocation(Constants.MOD_ID, "cocoon"));
 
 		ModuleCore.rootCommand.addChildCommand(new CommandButterfly());
 

--- a/src/main/java/forestry/sorting/ModuleSorting.java
+++ b/src/main/java/forestry/sorting/ModuleSorting.java
@@ -5,6 +5,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 
 import net.minecraftforge.common.capabilities.CapabilityManager;
 
@@ -46,14 +47,14 @@ public class ModuleSorting extends BlankForestryModule {
 	public void setupAPI() {
 		AlleleManager.filterRegistry = new FilterRegistry();
 
-		CapabilityManager.INSTANCE.register(IFilterLogic.class, new NullStorage<>(), ()->FakeFilterLogic.INSTANCE);
+		CapabilityManager.INSTANCE.register(IFilterLogic.class, new NullStorage<>(), () -> FakeFilterLogic.INSTANCE);
 	}
 
 	@Override
 	public void disabledSetupAPI() {
 		AlleleManager.filterRegistry = new DummyFilterRegistry();
 
-		CapabilityManager.INSTANCE.register(IFilterLogic.class, new NullStorage<>(), ()->FakeFilterLogic.INSTANCE);
+		CapabilityManager.INSTANCE.register(IFilterLogic.class, new NullStorage<>(), () -> FakeFilterLogic.INSTANCE);
 	}
 
 	@Override
@@ -68,44 +69,44 @@ public class ModuleSorting extends BlankForestryModule {
 
 	@Override
 	public void registerRecipes() {
-		if(ModuleHelper.isEnabled(ForestryModuleUids.APICULTURE)) {
+		if (ModuleHelper.isEnabled(ForestryModuleUids.APICULTURE)) {
 			RecipeUtil.addRecipe("genetic_filter_api", new ItemStack(getBlocks().filter, 2),
-				"WDW",
-				"PGP",
-				"BDB",
-				'D', OreDictUtil.GEM_DIAMOND,
-				'W', OreDictUtil.PLANK_WOOD,
-				'G', OreDictUtil.BLOCK_GLASS,
-				'B', OreDictUtil.GEAR_BRONZE,
-				'P', ModuleApiculture.getItems().propolis);
+					"WDW",
+					"PGP",
+					"BDB",
+					'D', OreDictUtil.GEM_DIAMOND,
+					'W', OreDictUtil.PLANK_WOOD,
+					'G', OreDictUtil.BLOCK_GLASS,
+					'B', OreDictUtil.GEAR_BRONZE,
+					'P', ModuleApiculture.getItems().propolis);
 		}
-		if(ModuleHelper.isEnabled(ForestryModuleUids.ARBORICULTURE)) {
+		if (ModuleHelper.isEnabled(ForestryModuleUids.ARBORICULTURE)) {
 			RecipeUtil.addRecipe("genetic_filter_arb", new ItemStack(getBlocks().filter, 2),
-				"WDW",
-				"FGF",
-				"BDB",
-				'D', OreDictUtil.GEM_DIAMOND,
-				'W', OreDictUtil.PLANK_WOOD,
-				'G', OreDictUtil.BLOCK_GLASS,
-				'B', OreDictUtil.GEAR_BRONZE,
-				'F', OreDictUtil.FRUIT_FORESTRY);
+					"WDW",
+					"FGF",
+					"BDB",
+					'D', OreDictUtil.GEM_DIAMOND,
+					'W', OreDictUtil.PLANK_WOOD,
+					'G', OreDictUtil.BLOCK_GLASS,
+					'B', OreDictUtil.GEAR_BRONZE,
+					'F', OreDictUtil.FRUIT_FORESTRY);
 		}
-		if(ModuleHelper.isEnabled(ForestryModuleUids.LEPIDOPTEROLOGY)) {
+		if (ModuleHelper.isEnabled(ForestryModuleUids.LEPIDOPTEROLOGY)) {
 			RecipeUtil.addRecipe("genetic_filter_lep", new ItemStack(getBlocks().filter, 2),
-				"WDW",
-				"FGF",
-				"BDB",
-				'D', OreDictUtil.GEM_DIAMOND,
-				'W', OreDictUtil.PLANK_WOOD,
-				'G', OreDictUtil.BLOCK_GLASS,
-				'B', OreDictUtil.GEAR_BRONZE,
-				'F', ModuleLepidopterology.getItems().caterpillarGE);
+					"WDW",
+					"FGF",
+					"BDB",
+					'D', OreDictUtil.GEM_DIAMOND,
+					'W', OreDictUtil.PLANK_WOOD,
+					'G', OreDictUtil.BLOCK_GLASS,
+					'B', OreDictUtil.GEAR_BRONZE,
+					'F', ModuleLepidopterology.getItems().caterpillarGE);
 		}
 	}
 
 	@Override
 	public void doInit() {
-		GameRegistry.registerTileEntity(TileGeneticFilter.class, "forestry.GeneticFilter");
-		((FilterRegistry)AlleleManager.filterRegistry).init();
+		GameRegistry.registerTileEntity(TileGeneticFilter.class, new ResourceLocation(Constants.MOD_ID, "geneticFilter"));
+		((FilterRegistry) AlleleManager.filterRegistry).init();
 	}
 }


### PR DESCRIPTION
Fixes errors such as 
```
21:36:47] [main/WARN] [FML]: Potentially Dangerous alternative prefix minecraft for name forestry.analyzer, expected forestry. This could be a intended override, but in most cases indicates a broken mod.
[21:36:47] [main/WARN] [FML]: Potentially Dangerous alternative prefix minecraft for name forestry.escritoire, expected forestry. This could be a intended override, but in most cases indicates a broken mod.
```
~~At the moment this will remove all tile entities in the world. So this will break things unless a datafixer is also included.~~