### PR TITLE
Include forestry prefix when logging

### DIFF
--- a/src/main/java/forestry/core/utils/Log.java
+++ b/src/main/java/forestry/core/utils/Log.java
@@ -38,7 +38,7 @@ public class Log {
 	}
 
 	private static void log(Level logLevel, String message, Object... params) {
-		LogManager.getLogger(Constants.MOD_ID).log(logLevel, String.format("[ Forestry ] %s", message), params);
+		LogManager.getLogger(Constants.MOD_ID).log(logLevel, String.format("[Forestry] %s", message), params);
 	}
 
 }

--- a/src/main/java/forestry/core/utils/Log.java
+++ b/src/main/java/forestry/core/utils/Log.java
@@ -10,9 +10,10 @@
  ******************************************************************************/
 package forestry.core.utils;
 
-import forestry.core.config.Constants;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+
+import forestry.core.config.Constants;
 
 public class Log {
 
@@ -37,7 +38,7 @@ public class Log {
 	}
 
 	private static void log(Level logLevel, String message, Object... params) {
-		LogManager.getLogger(Constants.MOD_ID).log(logLevel, message, params);
+		LogManager.getLogger(Constants.MOD_ID).log(logLevel, String.format("[ Forestry ] %s", message), params);
 	}
 
 }


### PR DESCRIPTION
See https://gist.github.com/temp1011/291c85c53b80a9f66a418cfc7315e8ee. This makes it clearer to see which mod is doing what in big packs. Maybe there is a better way to do this through forge or logger configuration.