### PR TITLE
fixed the localization names for the StorageJeiPlugin

### DIFF
--- a/src/main/java/forestry/storage/compat/StorageJeiPlugin.java
+++ b/src/main/java/forestry/storage/compat/StorageJeiPlugin.java
@@ -20,27 +20,27 @@ public class StorageJeiPlugin implements IModPlugin {
 
 		ItemRegistryBackpacks items = ModuleBackpacks.getItems();
 
-		JeiUtil.addDescription(registry, "minerBag",
+		JeiUtil.addDescription(registry, "miner_bag",
 				items.minerBackpack,
 				items.minerBackpackT2
 		);
-		JeiUtil.addDescription(registry, "diggerBag",
+		JeiUtil.addDescription(registry, "digger_bag",
 				items.diggerBackpack,
 				items.diggerBackpackT2
 		);
-		JeiUtil.addDescription(registry, "foresterBag",
+		JeiUtil.addDescription(registry, "forester_bag",
 				items.foresterBackpack,
 				items.foresterBackpackT2
 		);
-		JeiUtil.addDescription(registry, "hunter",
+		JeiUtil.addDescription(registry, "hunter_bag",
 				items.hunterBackpack,
 				items.hunterBackpackT2
 		);
-		JeiUtil.addDescription(registry, "adventurerBag",
+		JeiUtil.addDescription(registry, "adventurer_bag",
 				items.adventurerBackpack,
 				items.adventurerBackpackT2
 		);
-		JeiUtil.addDescription(registry, "builderBag",
+		JeiUtil.addDescription(registry, "builder_bag",
 				items.builderBackpack,
 				items.builderBackpackT2
 		);


### PR DESCRIPTION
I noticed while playing that the various backpacks' descriptions were just "for.jei.description.[type]Backpack."  The StorageJeiPlugin class uses the wrong names for the localization strings.  I've updated the strings to match the lang files.