### PR TITLE
BuildCraft support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ minecraft {
 }
 
 repositories {
-	maven {
-		url 'http://maven.epoxide.xyz'
-	}
+  maven {
+    url = 'http://maven.mcmoddev.com'
+  }
 	maven {
 		url "http://dvs1.progwml6.com/files/maven"
 	}
@@ -54,14 +54,18 @@ repositories {
 		name = "Modmuss50"
 		url = "http://maven.modmuss50.me"
 	}
+  maven {
+    url = 'https://mod-buildcraft.com/maven'
+  }
 }
 
 dependencies {
-	deobfCompile "net.darkhax.tesla:Tesla-${tesla_mcversion}:${tesla_version}"
+  deobfCompile "net.darkhax.tesla:Tesla-${tesla_mcversion}:${tesla_version}"
 	deobfCompile "mezz.jei:jei_${jei_mcversion}:${jei_version}:api"
 	runtime "mezz.jei:jei_${jei_mcversion}:${jei_version}"
 	deobfCompile "net.industrial-craft:industrialcraft-2:${ic2_version}:api"
 	deobfCompile "TechReborn:TechReborn-${TR_mcversion}:${TR_version}:api"
+  deobfCompile "com.mod-buildcraft:buildcraft:${buildcraft_version}"
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,8 @@ dependencies {
 	runtime "mezz.jei:jei_${jei_mcversion}:${jei_version}"
 	deobfCompile "net.industrial-craft:industrialcraft-2:${ic2_version}:api"
 	deobfCompile "TechReborn:TechReborn-${TR_mcversion}:${TR_version}:api"
-	deobfCompile "com.mod-buildcraft:buildcraft:${buildcraft_version}"
+	deobfProvided "com.mod-buildcraft:buildcraft-api:${buildcraft_version}"
+	runtimeOnly "com.mod-buildcraft:buildcraft:${buildcraft_version}"
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -112,9 +112,8 @@ jar {
 }
 
 task sourcesJar(type: Jar) {
-	// Not sure if this is how Abrar designed it, but grab the remapped src
+	from zipTree('build/retromapping/retromappedReplacedMain.jar') // Not sure if this is how Abrar designed it, but grab the remapped src
 	classifier = 'sources'
-	from zipTree('build/retromapping/retromappedReplacedMain.jar')
 }
 
 task apiJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
-    repositories {
-        jcenter()
-        maven { url = "http://files.minecraftforge.net/maven" }
-    }
-    dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
-        classpath "gradle.plugin.se.bjurr.gitchangelog:git-changelog-gradle-plugin:1.47"
-    }
+	repositories {
+		jcenter()
+		maven { url = "http://files.minecraftforge.net/maven" }
+	}
+	dependencies {
+		classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+		classpath "gradle.plugin.se.bjurr.gitchangelog:git-changelog-gradle-plugin:1.47"
+	}
 }
 
 plugins {
-    id "com.matthewprenger.cursegradle" version "1.0.9"
+	id "com.matthewprenger.cursegradle" version "1.0.9"
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 apply plugin: 'idea'
@@ -19,7 +19,7 @@ apply plugin: "se.bjurr.gitchangelog.git-changelog-gradle-plugin"
 
 version = version_major + '.' + version_minor + '.' + version_patch + '.' + getBuildNumber()
 if (project.hasProperty('buildQualifier')) {
-    version = project.version + '-' + project.buildQualifier
+	version = project.version + '-' + project.buildQualifier
 }
 group = "net.sengir.forestry" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "forestry_" + mcversion
@@ -31,140 +31,140 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 minecraft {
-    version = mcversion + "-" + forgeversion
-    runDir = "run"
-    mappings = mcp_mappings
+	version = mcversion + "-" + forgeversion
+	runDir = "run"
+	mappings = mcp_mappings
 
-    replace '@VERSION@', project.version
-    replace '@BUILD_NUMBER@', getBuildNumber()
+	replace '@VERSION@', project.version
+	replace '@BUILD_NUMBER@', getBuildNumber()
 }
 
 repositories {
-    maven {
-        url = 'http://maven.mcmoddev.com'
-    }
-    maven {
-        url "http://dvs1.progwml6.com/files/maven"
-    }
-    maven {
-        name = "ic2"
-        url = "http://maven.ic2.player.to/"
-    }
-    maven {
-        name = "Modmuss50"
-        url = "http://maven.modmuss50.me"
-    }
-    maven {
-        url = 'https://mod-buildcraft.com/maven'
-    }
+	maven {
+		url = 'http://maven.mcmoddev.com'
+	}
+	maven {
+		url "http://dvs1.progwml6.com/files/maven"
+	}
+	maven {
+		name = "ic2"
+		url = "http://maven.ic2.player.to/"
+	}
+	maven {
+		name = "Modmuss50"
+		url = "http://maven.modmuss50.me"
+	}
+	maven {
+		url = 'https://mod-buildcraft.com/maven'
+	}
 }
 
 dependencies {
-    deobfCompile "net.darkhax.tesla:Tesla-${tesla_mcversion}:${tesla_version}"
-    deobfCompile "mezz.jei:jei_${jei_mcversion}:${jei_version}:api"
-    runtime "mezz.jei:jei_${jei_mcversion}:${jei_version}"
-    deobfCompile "net.industrial-craft:industrialcraft-2:${ic2_version}:api"
-    deobfCompile "TechReborn:TechReborn-${TR_mcversion}:${TR_version}:api"
-    deobfCompile "com.mod-buildcraft:buildcraft:${buildcraft_version}"
+	deobfCompile "net.darkhax.tesla:Tesla-${tesla_mcversion}:${tesla_version}"
+	deobfCompile "mezz.jei:jei_${jei_mcversion}:${jei_version}:api"
+	runtime "mezz.jei:jei_${jei_mcversion}:${jei_version}"
+	deobfCompile "net.industrial-craft:industrialcraft-2:${ic2_version}:api"
+	deobfCompile "TechReborn:TechReborn-${TR_mcversion}:${TR_version}:api"
+	deobfCompile "com.mod-buildcraft:buildcraft:${buildcraft_version}"
 }
 
 configurations {
-    api
-    compile.extendsFrom api
+	api
+	compile.extendsFrom api
 }
 
 processResources {
 
-    // this will ensure that this task is redone when the versions change.
-    inputs.property "version", project.version
-    inputs.property "mcversion", project.minecraft.version
+	// this will ensure that this task is redone when the versions change.
+	inputs.property "version", project.version
+	inputs.property "mcversion", project.minecraft.version
 
-    // replace stuff in mcmod.info, nothing else
-    from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
+	// replace stuff in mcmod.info, nothing else
+	from(sourceSets.main.resources.srcDirs) {
+		include 'mcmod.info'
 
-        // replace version and mcversion
-        expand 'version': project.version, 'mcversion': project.minecraft.version
-    }
+		// replace version and mcversion
+		expand 'version': project.version, 'mcversion': project.minecraft.version
+	}
 
-    // copy everything else, thats not the mcmod.info
-    from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
-        exclude '**/*.md'
-    }
+	// copy everything else, thats not the mcmod.info
+	from(sourceSets.main.resources.srcDirs) {
+		exclude 'mcmod.info'
+		exclude '**/*.md'
+	}
 
-    // Move access transformers to META-INF
-    rename '(.+_at.cfg)', 'META-INF/$1'
+	// Move access transformers to META-INF
+	rename '(.+_at.cfg)', 'META-INF/$1'
 }
 
 // prevent java 8's strict doclint for javadocs from failing builds
 allprojects {
-    tasks.withType(Javadoc) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-    }
+	tasks.withType(Javadoc) {
+		options.addStringOption('Xdoclint:none', '-quiet')
+	}
 }
 
 jar {
-    manifest {
-        attributes 'FMLAT': 'forestry_at.cfg'
-    }
+	manifest {
+		attributes 'FMLAT': 'forestry_at.cfg'
+	}
 }
 
 task sourcesJar(type: Jar) {
-    from zipTree('build/retromapping/retromappedReplacedMain.jar')
-    // Not sure if this is how Abrar designed it, but grab the remapped src
-    classifier = 'sources'
+	from zipTree('build/retromapping/retromappedReplacedMain.jar')
+	// Not sure if this is how Abrar designed it, but grab the remapped src
+	classifier = 'sources'
 }
 
 task apiJar(type: Jar) {
-    // TODO: when FG bug is fixed, remove allSource from the api jar.
-    // https://github.com/MinecraftForge/ForgeGradle/issues/369
-    // Gradle should be able to pull them from the -sources jar.
-    from sourceSets.main.allSource
-    from sourceSets.main.output
-    include 'forestry/api/**'
-    classifier = 'api'
+	// TODO: when FG bug is fixed, remove allSource from the api jar.
+	// https://github.com/MinecraftForge/ForgeGradle/issues/369
+	// Gradle should be able to pull them from the -sources jar.
+	from sourceSets.main.allSource
+	from sourceSets.main.output
+	include 'forestry/api/**'
+	classifier = 'api'
 }
 
 artifacts {
-    archives sourcesJar
-    archives apiJar
+	archives sourcesJar
+	archives apiJar
 }
 
 uploadArchives {
-    repositories {
-        if (project.hasProperty('mavenDir')) {
-            mavenDeployer {
-                repository(url: "file://" + mavenDir)
-            }
-        } else {
-            println 'Archives upload disabled, mavenDir in gradle.properties is missing.'
-        }
-    }
+	repositories {
+		if (project.hasProperty('mavenDir')) {
+			mavenDeployer {
+				repository(url: "file://" + mavenDir)
+			}
+		} else {
+			println 'Archives upload disabled, mavenDir in gradle.properties is missing.'
+		}
+	}
 }
 
 def getBuildNumber() {
-    return "$System.env.BUILD_NUMBER" != "null" ? "$System.env.BUILD_NUMBER" : "0"
+	return "$System.env.BUILD_NUMBER" != "null" ? "$System.env.BUILD_NUMBER" : "0"
 }
 
 task makeChangelog(type: se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask) {
-    filePath = "changelog.html"
-    untaggedName = "Current release ${project.version}"
-    fromCommit = "5a3850c2642e535656d090d1473054d5fa8d3331"
-    toRef = "HEAD"
-    templateContent = file('changelog.mustache').getText('UTF-8')
+	filePath = "changelog.html"
+	untaggedName = "Current release ${project.version}"
+	fromCommit = "5a3850c2642e535656d090d1473054d5fa8d3331"
+	toRef = "HEAD"
+	templateContent = file('changelog.mustache').getText('UTF-8')
 }
 
 curseforge {
-    apiKey = project.hasProperty('curseforge_apikey') ? project.curseforge_apikey : '0'
-    project {
-        id = curse_project_id
-        changelog = file('changelog.html')
-        changelogType = 'html'
-        releaseType = 'beta'
-    }
+	apiKey = project.hasProperty('curseforge_apikey') ? project.curseforge_apikey : '0'
+	project {
+		id = curse_project_id
+		changelog = file('changelog.html')
+		changelogType = 'html'
+		releaseType = 'beta'
+	}
 }
 
 afterEvaluate {
-    tasks.curseforge59751.dependsOn.add(makeChangelog)
+	tasks.curseforge59751.dependsOn.add(makeChangelog)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -111,9 +111,9 @@ jar {
 }
 
 task sourcesJar(type: Jar) {
-	from zipTree('build/retromapping/retromappedReplacedMain.jar')
 	// Not sure if this is how Abrar designed it, but grab the remapped src
 	classifier = 'sources'
+	from zipTree('build/retromapping/retromappedReplacedMain.jar')
 }
 
 task apiJar(type: Jar) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ jei_mcversion=1.12.2
 ic2_version=2.8.24-ex112
 TR_mcversion=1.12.2
 TR_version=2.13.2.561
+buildcraft_version=7.99.17
 version_major=5
 version_minor=8
 version_patch=0

--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -15,6 +15,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 import java.io.File;
 
+import forestry.plugins.*;
 import net.minecraft.item.Item;
 
 import net.minecraftforge.client.event.ModelRegistryEvent;
@@ -52,10 +53,6 @@ import forestry.core.proxy.Proxies;
 import forestry.core.worldgen.WorldGenerator;
 import forestry.modules.ForestryModules;
 import forestry.modules.ModuleManager;
-import forestry.plugins.ForestryCompatPlugins;
-import forestry.plugins.PluginIC2;
-import forestry.plugins.PluginNatura;
-import forestry.plugins.PluginTechReborn;
 
 /**
  * Forestry Minecraft Mod
@@ -73,7 +70,8 @@ import forestry.plugins.PluginTechReborn;
 				+ "after:" + PluginIC2.MOD_ID + ";"
 				+ "after:" + PluginNatura.MOD_ID + ";"
 				+ "after:toughasnails;"
-				+ "after:" + PluginTechReborn.MOD_ID + ";")
+				+ "after:" + PluginTechReborn.MOD_ID + ";"
+				+ "after:" + PluginBuildCraftFuels.MOD_ID + ";")
 public class Forestry {
 
 	@SuppressWarnings("NullableProblems")

--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -15,7 +15,11 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 import java.io.File;
 
-import forestry.plugins.*;
+import forestry.plugins.ForestryCompatPlugins;
+import forestry.plugins.PluginBuildCraftFuels;
+import forestry.plugins.PluginIC2;
+import forestry.plugins.PluginNatura;
+import forestry.plugins.PluginTechReborn;
 import net.minecraft.item.Item;
 
 import net.minecraftforge.client.event.ModelRegistryEvent;

--- a/src/main/java/forestry/apiculture/ModuleApiculture.java
+++ b/src/main/java/forestry/apiculture/ModuleApiculture.java
@@ -942,7 +942,8 @@ public class ModuleApiculture extends BlankForestryModule {
 	}
 
 	@Override
-	public void populateChunk(IChunkGenerator chunkGenerator, World world, Random rand, int chunkX, int chunkZ, boolean hasVillageGenerated) {
+	public void populateChunk(IChunkGenerator chunkGenerator, World world, Random rand, int chunkX, int chunkZ,
+			boolean hasVillageGenerated) {
 		if (!world.provider.getDimensionType().equals(DimensionType.THE_END)) {
 			return;
 		}

--- a/src/main/java/forestry/apiculture/ModuleApiculture.java
+++ b/src/main/java/forestry/apiculture/ModuleApiculture.java
@@ -13,14 +13,6 @@ package forestry.apiculture;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
-import javax.annotation.Nullable;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Random;
-import java.util.Set;
-
 import net.minecraft.block.BlockFlower;
 import net.minecraft.block.BlockFlowerPot;
 import net.minecraft.block.properties.PropertyEnum;
@@ -42,7 +34,6 @@ import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.gen.IChunkGenerator;
 import net.minecraft.world.storage.loot.LootTableList;
-
 import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.MinecraftForge;
@@ -50,8 +41,6 @@ import net.minecraftforge.common.brewing.BrewingRecipeRegistry;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.registries.IForgeRegistry;
-
 import net.minecraftforge.fml.common.event.FMLInterModComms.IMCMessage;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
@@ -59,6 +48,16 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.common.registry.VillagerRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.registries.IForgeRegistry;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+
+import javax.annotation.Nullable;
 
 import forestry.Forestry;
 import forestry.api.apiculture.BeeManager;
@@ -109,6 +108,7 @@ import forestry.apiculture.multiblock.TileAlvearySwarmer;
 import forestry.apiculture.network.PacketRegistryApiculture;
 import forestry.apiculture.tiles.TileCandle;
 import forestry.apiculture.tiles.TileHive;
+import forestry.apiculture.trigger.ApicultureTriggers;
 import forestry.apiculture.worldgen.HiveDecorator;
 import forestry.apiculture.worldgen.HiveDescription;
 import forestry.apiculture.worldgen.HiveGenHelper;
@@ -244,11 +244,10 @@ public class ModuleApiculture extends BlankForestryModule {
 		}
 	}
 
-	// TODO: Buildcraft for 1.9
-	//	@Override
-	//	public void registerTriggers() {
-	//		ApicultureTriggers.initialize();
-	//	}
+	@Override
+	public void registerTriggers() {
+		ApicultureTriggers.initialize();
+	}
 
 	@Override
 	public void doInit() {
@@ -944,7 +943,7 @@ public class ModuleApiculture extends BlankForestryModule {
 
 	@Override
 	public void populateChunk(IChunkGenerator chunkGenerator, World world, Random rand, int chunkX, int chunkZ,
-			boolean hasVillageGenerated) {
+														boolean hasVillageGenerated) {
 		if (!world.provider.getDimensionType().equals(DimensionType.THE_END)) {
 			return;
 		}

--- a/src/main/java/forestry/apiculture/ModuleApiculture.java
+++ b/src/main/java/forestry/apiculture/ModuleApiculture.java
@@ -942,8 +942,7 @@ public class ModuleApiculture extends BlankForestryModule {
 	}
 
 	@Override
-	public void populateChunk(IChunkGenerator chunkGenerator, World world, Random rand, int chunkX, int chunkZ,
-														boolean hasVillageGenerated) {
+	public void populateChunk(IChunkGenerator chunkGenerator, World world, Random rand, int chunkX, int chunkZ, boolean hasVillageGenerated) {
 		if (!world.provider.getDimensionType().equals(DimensionType.THE_END)) {
 			return;
 		}

--- a/src/main/java/forestry/apiculture/multiblock/TileAlvearyPlain.java
+++ b/src/main/java/forestry/apiculture/multiblock/TileAlvearyPlain.java
@@ -10,8 +10,23 @@
  ******************************************************************************/
 package forestry.apiculture.multiblock;
 
-//@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
-public class TileAlvearyPlain extends TileAlveary {//implements ITriggerProvider {
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fml.common.Optional;
+
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.ITriggerExternal;
+import buildcraft.api.statements.ITriggerInternal;
+import buildcraft.api.statements.ITriggerInternalSided;
+import buildcraft.api.statements.ITriggerProvider;
+import forestry.apiculture.trigger.ApicultureTriggers;
+
+@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
+public class TileAlvearyPlain extends TileAlveary implements ITriggerProvider {
 
 	@Override
 	public boolean allowsAutomation() {
@@ -19,19 +34,18 @@ public class TileAlvearyPlain extends TileAlveary {//implements ITriggerProvider
 	}
 
 	/* ITRIGGERPROVIDER */
-	// TODO: buildcraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerInternal> getInternalTriggers(IStatementContainer container) {
-//		return null;
-//	}
-//
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		Collection<ITriggerExternal> res = new ArrayList<>();
-//		res.add(ApicultureTriggers.missingQueen);
-//		res.add(ApicultureTriggers.missingDrone);
-//		return res;
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addInternalTriggers(Collection<ITriggerInternal> triggers, IStatementContainer container) { }
+
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addInternalSidedTriggers(Collection<ITriggerInternalSided> triggers, IStatementContainer container, @Nonnull EnumFacing side) { }
+
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		triggers.add(ApicultureTriggers.missingQueen);
+		triggers.add(ApicultureTriggers.missingDrone);
+	}
 }

--- a/src/main/java/forestry/apiculture/multiblock/TileAlvearyPlain.java
+++ b/src/main/java/forestry/apiculture/multiblock/TileAlvearyPlain.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.apiculture.multiblock;
 
+import forestry.core.config.Constants;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.common.Optional;
@@ -25,7 +26,7 @@ import buildcraft.api.statements.ITriggerInternalSided;
 import buildcraft.api.statements.ITriggerProvider;
 import forestry.apiculture.trigger.ApicultureTriggers;
 
-@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
+@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = Constants.BCLIB_MOD_ID)
 public class TileAlvearyPlain extends TileAlveary implements ITriggerProvider {
 
 	@Override
@@ -34,15 +35,15 @@ public class TileAlvearyPlain extends TileAlveary implements ITriggerProvider {
 	}
 
 	/* ITRIGGERPROVIDER */
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addInternalTriggers(Collection<ITriggerInternal> triggers, IStatementContainer container) { }
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addInternalSidedTriggers(Collection<ITriggerInternalSided> triggers, IStatementContainer container, @Nonnull EnumFacing side) { }
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		triggers.add(ApicultureTriggers.missingQueen);

--- a/src/main/java/forestry/apiculture/tiles/TileApiary.java
+++ b/src/main/java/forestry/apiculture/tiles/TileApiary.java
@@ -10,11 +10,25 @@
  ******************************************************************************/
 package forestry.apiculture.tiles;
 
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.Tuple;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
+import buildcraft.api.statements.ITriggerExternal;
 import forestry.api.apiculture.IBeeHousingInventory;
 import forestry.api.apiculture.IBeeListener;
 import forestry.api.apiculture.IBeeModifier;
@@ -26,13 +40,7 @@ import forestry.apiculture.gui.ContainerBeeHousing;
 import forestry.apiculture.gui.GuiBeeHousing;
 import forestry.apiculture.inventory.IApiaryInventory;
 import forestry.apiculture.inventory.InventoryApiary;
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.Container;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.Tuple;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import forestry.apiculture.trigger.ApicultureTriggers;
 
 public class TileApiary extends TileBeeHousingBase implements IApiary {
 	private final IBeeModifier beeModifier = new ApiaryBeeModifier();
@@ -76,16 +84,14 @@ public class TileApiary extends TileBeeHousingBase implements IApiary {
 	}
 
 	/* ITRIGGERPROVIDER */
-	// TODO: buildcraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		LinkedList<ITriggerExternal> res = new LinkedList<>();
-//		res.add(ApicultureTriggers.missingQueen);
-//		res.add(ApicultureTriggers.missingDrone);
-//		res.add(ApicultureTriggers.noFrames);
-//		return res;
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		super.addExternalTriggers(triggers, side, tile);
+		triggers.add(ApicultureTriggers.missingQueen);
+		triggers.add(ApicultureTriggers.missingDrone);
+		triggers.add(ApicultureTriggers.noFrames);
+	}
 
 	@Override
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/forestry/apiculture/tiles/TileApiary.java
+++ b/src/main/java/forestry/apiculture/tiles/TileApiary.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.apiculture.tiles;
 
+import forestry.core.config.Constants;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -84,7 +85,7 @@ public class TileApiary extends TileBeeHousingBase implements IApiary {
 	}
 
 	/* ITRIGGERPROVIDER */
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		super.addExternalTriggers(triggers, side, tile);

--- a/src/main/java/forestry/apiculture/trigger/ApicultureTriggers.java
+++ b/src/main/java/forestry/apiculture/trigger/ApicultureTriggers.java
@@ -10,16 +10,17 @@
  ******************************************************************************/
 package forestry.apiculture.trigger;
 
-// TODO: Buildcraft for 1.9
+import forestry.core.triggers.Trigger;
+
 public class ApicultureTriggers {
-//	public static Trigger noFrames;
-//	public static Trigger missingQueen;
-//	public static Trigger missingDrone;
-//
-//	public static void initialize() {
-//		noFrames = new TriggerNoFrames();
-//
-//		missingQueen = new TriggerMissingQueen();
-//		missingDrone = new TriggerMissingDrone();
-//	}
+	public static Trigger noFrames;
+	public static Trigger missingQueen;
+	public static Trigger missingDrone;
+
+	public static void initialize() {
+		noFrames = new TriggerNoFrames();
+
+		missingQueen = new TriggerMissingQueen();
+		missingDrone = new TriggerMissingDrone();
+	}
 }

--- a/src/main/java/forestry/apiculture/trigger/TriggerMissingDrone.java
+++ b/src/main/java/forestry/apiculture/trigger/TriggerMissingDrone.java
@@ -10,25 +10,33 @@
  ******************************************************************************/
 package forestry.apiculture.trigger;
 
-// TODO: Buildcraft for 1.9
-public class TriggerMissingDrone {//extends Trigger {
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-//	public TriggerMissingDrone() {
-//		super("missingDrone");
-//	}
-//
-//	/**
-//	 * Return true if the tile given in parameter activates the trigger, given the parameters.
-//	 */
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (!(tile instanceof IErrorLogicSource)) {
-//			return false;
-//		}
-//
-//		IErrorLogicSource apiary = (IErrorLogicSource) tile;
-//		return apiary.getErrorLogic().contains(EnumErrorCode.NO_DRONE);
-//	}
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.api.core.IErrorLogicSource;
+import forestry.core.errors.EnumErrorCode;
+import forestry.core.triggers.Trigger;
+
+public class TriggerMissingDrone extends Trigger {
+
+	public TriggerMissingDrone() {
+		super("missingDrone");
+	}
+
+	/**
+	 * Return true if the tile given in parameter activates the trigger, given the parameters.
+	 */
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+
+		if (!(tile instanceof IErrorLogicSource)) {
+			return false;
+		}
+
+		IErrorLogicSource apiary = (IErrorLogicSource) tile;
+		return apiary.getErrorLogic().contains(EnumErrorCode.NO_DRONE);
+	}
 
 }

--- a/src/main/java/forestry/apiculture/trigger/TriggerMissingDrone.java
+++ b/src/main/java/forestry/apiculture/trigger/TriggerMissingDrone.java
@@ -22,7 +22,7 @@ import forestry.core.triggers.Trigger;
 public class TriggerMissingDrone extends Trigger {
 
 	public TriggerMissingDrone() {
-		super("missingDrone");
+		super("missingDrone", "missing_drone");
 	}
 
 	/**

--- a/src/main/java/forestry/apiculture/trigger/TriggerMissingQueen.java
+++ b/src/main/java/forestry/apiculture/trigger/TriggerMissingQueen.java
@@ -22,7 +22,7 @@ import forestry.core.triggers.Trigger;
 public class TriggerMissingQueen extends Trigger {
 
 	public TriggerMissingQueen() {
-		super("missingQueen");
+		super("missingQueen", "missing_queen");
 	}
 
 	/**

--- a/src/main/java/forestry/apiculture/trigger/TriggerMissingQueen.java
+++ b/src/main/java/forestry/apiculture/trigger/TriggerMissingQueen.java
@@ -10,24 +10,32 @@
  ******************************************************************************/
 package forestry.apiculture.trigger;
 
-public class TriggerMissingQueen {//extends Trigger {
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-//	public TriggerMissingQueen() {
-//		super("missingQueen");
-//	}
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.api.core.IErrorLogicSource;
+import forestry.core.errors.EnumErrorCode;
+import forestry.core.triggers.Trigger;
+
+public class TriggerMissingQueen extends Trigger {
+
+	public TriggerMissingQueen() {
+		super("missingQueen");
+	}
 
 	/**
 	 * Return true if the tile given in parameter activates the trigger, given the parameters.
 	 */
-	// TODO: buildcraft for 1.9
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (!(tile instanceof IErrorLogicSource)) {
-//			return false;
-//		}
-//
-//		IErrorLogicSource apiary = (IErrorLogicSource) tile;
-//		return apiary.getErrorLogic().contains(EnumErrorCode.NO_QUEEN);
-//	}
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+
+		if (!(tile instanceof IErrorLogicSource)) {
+			return false;
+		}
+
+		IErrorLogicSource apiary = (IErrorLogicSource) tile;
+		return apiary.getErrorLogic().contains(EnumErrorCode.NO_QUEEN);
+	}
 }

--- a/src/main/java/forestry/apiculture/trigger/TriggerNoFrames.java
+++ b/src/main/java/forestry/apiculture/trigger/TriggerNoFrames.java
@@ -22,7 +22,7 @@ import forestry.core.triggers.Trigger;
 public class TriggerNoFrames extends Trigger {
 
 	public TriggerNoFrames() {
-		super("noFrames");
+		super("noFrames", "no_frames");
 	}
 
 	/**

--- a/src/main/java/forestry/apiculture/trigger/TriggerNoFrames.java
+++ b/src/main/java/forestry/apiculture/trigger/TriggerNoFrames.java
@@ -10,28 +10,36 @@
  ******************************************************************************/
 package forestry.apiculture.trigger;
 
-public class TriggerNoFrames {//extends Trigger {
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-//	public TriggerNoFrames() {
-//		super("noFrames");
-//	}
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.apiculture.inventory.InventoryApiary;
+import forestry.apiculture.tiles.TileApiary;
+import forestry.core.triggers.Trigger;
+
+public class TriggerNoFrames extends Trigger {
+
+	public TriggerNoFrames() {
+		super("noFrames");
+	}
 
 	/**
 	 * Return true if the tile given in parameter activates the trigger, given the parameters.
 	 */
-	// TODO: buildcraft for 1.9
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (!(tile instanceof TileApiary)) {
-//			return false;
-//		}
-//
-//		TileApiary apiary = (TileApiary) tile;
-//
-//		InventoryApiary inventory = (InventoryApiary) apiary.getInternalInventory();
-//
-//		return inventory.getFrames().isEmpty();
-//	}
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+
+		if (!(tile instanceof TileApiary)) {
+			return false;
+		}
+
+		TileApiary apiary = (TileApiary) tile;
+
+		InventoryApiary inventory = (InventoryApiary) apiary.getInternalInventory();
+
+		return inventory.getFrames().isEmpty();
+	}
 
 }

--- a/src/main/java/forestry/core/capabilities/HasWorkWrapper.java
+++ b/src/main/java/forestry/core/capabilities/HasWorkWrapper.java
@@ -1,0 +1,27 @@
+package forestry.core.capabilities;
+
+import buildcraft.api.tiles.IHasWork;
+import forestry.core.config.Constants;
+import forestry.core.tiles.TilePowered;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.fml.common.Optional;
+
+@Optional.Interface(iface = "buildcraft.api.tiles.IHasWork", modid = Constants.BCLIB_MOD_ID)
+public class HasWorkWrapper implements IHasWork {
+
+	@CapabilityInject(IHasWork.class)
+	public static Capability<IHasWork> CAPABILITY_HAS_WORK;
+
+	private final TilePowered self;
+
+	public HasWorkWrapper(TilePowered self) {
+		this.self = self;
+	}
+
+	@Override
+	public boolean hasWork() {
+		return self.hasWork();
+	}
+
+}

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -61,10 +61,10 @@ public class Config {
 	// Graphics
 	public static boolean enableParticleFX = true;
 
-	//Humus
+	// Humus
 	public static int humusDegradeDelimiter = 3;
 
-	//Greenhouse
+	// Greenhouse
 	public static int climateSourceRange = 36;
 	public static float climateSourceEnergyModifier = 1.5F;
 	public static int greenhouseSize = 4;
@@ -136,6 +136,12 @@ public class Config {
 	public static final LinkedListMultimap<String, String> hints = LinkedListMultimap.create();
 	public static boolean enableEnergyStat = true;
 
+	// Energy
+	public static boolean enableRF = true;
+	public static boolean enableMJ = true;
+	public static boolean enableTesla = true;
+	public static EnergyDisplayMode energyDisplayMode = EnergyDisplayMode.RF;
+
 	public static boolean isStructureEnabled(String uid) {
 		return !Config.disabledStructures.contains(uid);
 	}
@@ -200,7 +206,7 @@ public class Config {
 
 	public static void load(Side side) {
 		File configCommonFile = new File(Forestry.instance.getConfigFolder(), CATEGORY_COMMON + ".cfg");
-		configCommon = new LocalizedConfiguration(configCommonFile, "1.2.0");
+		configCommon = new LocalizedConfiguration(configCommonFile, "1.2.1");
 		loadConfigCommon(side);
 
 		File configFluidsFile = new File(Forestry.instance.getConfigFolder(), CATEGORY_FLUIDS + ".cfg");
@@ -234,13 +240,13 @@ public class Config {
 			// Make sure the default mode files are there.
 
 			File opMode = new File(Forestry.instance.getConfigFolder(), "gamemodes/OP.cfg");
-			CopyFileToFS(opMode, "/config/forestry/gamemodes/OP.cfg");
+			copyFileToFS(opMode, "/config/forestry/gamemodes/OP.cfg");
 
 			File normalMode = new File(Forestry.instance.getConfigFolder(), "gamemodes/NORMAL.cfg");
-			CopyFileToFS(normalMode, "/config/forestry/gamemodes/NORMAL.cfg");
+			copyFileToFS(normalMode, "/config/forestry/gamemodes/NORMAL.cfg");
 
 			File hardMode = new File(Forestry.instance.getConfigFolder(), "gamemodes/HARD.cfg");
-			CopyFileToFS(hardMode, "/config/forestry/gamemodes/HARD.cfg");
+			copyFileToFS(hardMode, "/config/forestry/gamemodes/HARD.cfg");
 		}
 
 		// RetroGen
@@ -354,6 +360,13 @@ public class Config {
 
 		spawnWithBook = configCommon.getBooleanLocalized("tweaks.book", "spawn", spawnWithBook);
 
+		enableRF = configCommon.getBooleanLocalized("power.types", "rf", true);
+		enableMJ = configCommon.getBooleanLocalized("power.types", "mj", true);
+		enableTesla = configCommon.getBooleanLocalized("power.types", "tesla", true);
+
+		energyDisplayMode = configCommon.getEnumLocalized("power.display", "mode", EnergyDisplayMode.RF, EnergyDisplayMode.values());
+
+
 		configCommon.save();
 	}
 
@@ -379,7 +392,7 @@ public class Config {
 		configFluid.save();
 	}
 
-	private static void CopyFileToFS(File destination, String resourcePath) {
+	private static void copyFileToFS(File destination, String resourcePath) {
 		InputStream stream = Config.class.getResourceAsStream(resourcePath);
 		OutputStream outstream;
 		int readBytes;

--- a/src/main/java/forestry/core/config/Constants.java
+++ b/src/main/java/forestry/core/config/Constants.java
@@ -27,6 +27,7 @@ public class Constants implements IForestryConstants {
 
 	public static final String RF_MOD_ID = "CoFHAPI|energy";
 	public static final String TESLA_MOD_ID = "tesla";
+	public static final String BCLIB_MOD_ID = "buildcraftlib";
 
 	public static final int FLAG_BLOCK_UPDATE = 1;
 	public static final int FLAG_BLOCK_SYNC = 2;

--- a/src/main/java/forestry/core/config/EnergyDisplayMode.java
+++ b/src/main/java/forestry/core/config/EnergyDisplayMode.java
@@ -1,5 +1,10 @@
 package forestry.core.config;
 
+import net.minecraftforge.client.MinecraftForgeClient;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
 public enum EnergyDisplayMode {
 	RF("RF", 1),
 	FE("FE", 1),
@@ -15,10 +20,19 @@ public enum EnergyDisplayMode {
 	}
 
 	public String formatRate(int energy) {
-		return String.format("%.0f %s/t", energy * factor, energyName);
+		String amountString = formatEnergyNum(energy);
+		return String.format("%s %s/t", amountString, energyName);
 	}
 
 	public String formatEnergyValue(int energy) {
-		return String.format("%.0f %s", energy * factor, energyName);
+		String amountString = formatEnergyNum(energy);
+		return String.format("%s %s", amountString, energyName);
+	}
+
+	private String formatEnergyNum(int energy) {
+		Locale locale = MinecraftForgeClient.getLocale();
+		NumberFormat numberFormat = NumberFormat.getIntegerInstance(locale);
+		float amount = energy * factor;
+		return numberFormat.format(amount);
 	}
 }

--- a/src/main/java/forestry/core/config/EnergyDisplayMode.java
+++ b/src/main/java/forestry/core/config/EnergyDisplayMode.java
@@ -1,0 +1,24 @@
+package forestry.core.config;
+
+public enum EnergyDisplayMode {
+	RF("RF", 1),
+	FE("FE", 1),
+	MJ("MJ", 0.1f),
+	TESLA("T", 1);
+
+	private final String energyName;
+	private final float factor;
+
+	EnergyDisplayMode(String energyName, float factor) {
+		this.energyName = energyName;
+		this.factor = factor;
+	}
+
+	public String formatRate(int energy) {
+		return String.format("%.0f %s/t", energy * factor, energyName);
+	}
+
+	public String formatEnergyValue(int energy) {
+		return String.format("%.0f %s", energy * factor, energyName);
+	}
+}

--- a/src/main/java/forestry/core/gui/ledgers/PowerLedger.java
+++ b/src/main/java/forestry/core/gui/ledgers/PowerLedger.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.core.gui.ledgers;
 
+import forestry.core.config.Config;
 import forestry.core.render.TextureManagerForestry;
 import forestry.core.utils.Translator;
 import forestry.energy.EnergyManager;
@@ -41,18 +42,18 @@ public class PowerLedger extends Ledger {
 		drawHeader(Translator.translateToLocal("for.gui.energy"), xHeader, y + 8);
 
 		drawSubheader(Translator.translateToLocal("for.gui.stored") + ':', xBody, y + 20);
-		drawText(energyManager.getEnergyStored() + " RF", xBody, y + 32);
+		drawText(Config.energyDisplayMode.formatEnergyValue(energyManager.getEnergyStored()), xBody, y + 32);
 
 		drawSubheader(Translator.translateToLocal("for.gui.maxenergy") + ':', xBody, y + 44);
-		drawText(energyManager.getMaxEnergyStored() + " RF", xBody, y + 56);
+		drawText(Config.energyDisplayMode.formatEnergyValue(energyManager.getMaxEnergyStored()), xBody, y + 56);
 
 		drawSubheader(Translator.translateToLocal("for.gui.maxenergyreceive") + ':', xBody, y + 68);
-		drawText(energyManager.getMaxEnergyReceived() + " RF", xBody, y + 80);
+		drawText(Config.energyDisplayMode.formatEnergyValue(energyManager.getMaxEnergyReceived()), xBody, y + 80);
 	}
 
 	@Override
 	public String getTooltip() {
-		return energyManager.getEnergyStored() + " RF";
+		return Config.energyDisplayMode.formatEnergyValue(energyManager.getEnergyStored());
 	}
 
 }

--- a/src/main/java/forestry/core/items/ItemWrench.java
+++ b/src/main/java/forestry/core/items/ItemWrench.java
@@ -10,16 +10,21 @@
  ******************************************************************************/
 package forestry.core.items;
 
+import buildcraft.api.tools.IToolWrench;
+import forestry.core.config.Constants;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Optional;
 
-//@Optional.Interface(iface = "buildcraft.api.tools.IToolWrench", modid = "BuildCraftAPI|tools")
-public class ItemWrench extends ItemForestry {//implements IToolWrench {
+@Optional.Interface(iface = "buildcraft.api.tools.IToolWrench", modid = Constants.BCLIB_MOD_ID)
+public class ItemWrench extends ItemForestry implements IToolWrench {
 
 	public ItemWrench() {
 		setHarvestLevel("wrench", 0);
@@ -35,23 +40,11 @@ public class ItemWrench extends ItemForestry {//implements IToolWrench {
 		return EnumActionResult.FAIL;
 	}
 
-	/*
 	@Override
-	public boolean canWrench(EntityPlayer player, BlockPos pos) {
+	public boolean canWrench(EntityPlayer player, EnumHand hand, ItemStack wrench, RayTraceResult rayTrace) {
 		return true;
 	}
 
 	@Override
-	public void wrenchUsed(EntityPlayer player, BlockPos pos) {
-	}
-
-	@Override
-	public boolean canWrench(EntityPlayer entityPlayer, Entity entity) {
-		return true;
-	}
-
-	@Override
-	public void wrenchUsed(EntityPlayer entityPlayer, Entity entity) {
-	}
-	*/
+	public void wrenchUsed(EntityPlayer player, EnumHand hand, ItemStack wrench, RayTraceResult rayTrace) {}
 }

--- a/src/main/java/forestry/core/tiles/TileBase.java
+++ b/src/main/java/forestry/core/tiles/TileBase.java
@@ -47,7 +47,7 @@ public abstract class TileBase extends TileForestry {
 
 	@Nonnull
 	public EnumFacing getFacing() {
-		return EnumFacing.getFront(getBlockMetadata());
+		return getWorld().getBlockState(getPos()).getValue(BlockBase.FACING);
 	}
 
 }

--- a/src/main/java/forestry/core/tiles/TileBase.java
+++ b/src/main/java/forestry/core/tiles/TileBase.java
@@ -14,11 +14,14 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import forestry.core.blocks.BlockBase;
 import forestry.core.gui.GuiHandler;
+
+import javax.annotation.Nonnull;
 
 public abstract class TileBase extends TileForestry {
 
@@ -41,4 +44,10 @@ public abstract class TileBase extends TileForestry {
 		Block newBlock = newState.getBlock();
 		return oldBlock != newBlock || !(oldBlock instanceof BlockBase) || !(newBlock instanceof BlockBase);
 	}
+
+	@Nonnull
+	public EnumFacing getFacing() {
+		return EnumFacing.getFront(getBlockMetadata());
+	}
+
 }

--- a/src/main/java/forestry/core/tiles/TileEngine.java
+++ b/src/main/java/forestry/core/tiles/TileEngine.java
@@ -300,18 +300,15 @@ public abstract class TileEngine extends TileBase implements IActivatable, IStre
 
 	@Override
 	public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing) {
-		return (getFacing() == facing && energyManager.hasCapability(capability)) ||
-				super.hasCapability(capability, facing);
+		return energyManager.hasCapability(capability) || super.hasCapability(capability, facing);
 	}
 
 	@Override
 	@Nullable
 	public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
-		if (getFacing() == facing) {
-			T energyCapability = energyManager.getCapability(capability);
-			if (energyCapability != null) {
-				return energyCapability;
-			}
+		T energyCapability = energyManager.getCapability(capability);
+		if (energyCapability != null) {
+			return energyCapability;
 		}
 		return super.getCapability(capability, facing);
 	}

--- a/src/main/java/forestry/core/tiles/TileEngine.java
+++ b/src/main/java/forestry/core/tiles/TileEngine.java
@@ -10,19 +10,6 @@
  ******************************************************************************/
 package forestry.core.tiles;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-
-import net.minecraftforge.common.capabilities.Capability;
-
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
 import forestry.api.core.IErrorLogic;
 import forestry.core.blocks.BlockBase;
 import forestry.core.config.Constants;
@@ -34,6 +21,16 @@ import forestry.core.utils.NetworkUtil;
 import forestry.energy.EnergyHelper;
 import forestry.energy.EnergyManager;
 import forestry.energy.EnergyTransferMode;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
 
 public abstract class TileEngine extends TileBase implements IActivatable, IStreamableGui {
 	private static final int CANT_SEND_ENERGY_TIME = 20;
@@ -303,15 +300,18 @@ public abstract class TileEngine extends TileBase implements IActivatable, IStre
 
 	@Override
 	public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing) {
-		return energyManager.hasCapability(capability) || super.hasCapability(capability, facing);
+		return (getFacing() == facing && energyManager.hasCapability(capability)) ||
+				super.hasCapability(capability, facing);
 	}
 
 	@Override
 	@Nullable
 	public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
-		T energyCapability = energyManager.getCapability(capability);
-		if (energyCapability != null) {
-			return energyCapability;
+		if (getFacing() == facing) {
+			T energyCapability = energyManager.getCapability(capability);
+			if (energyCapability != null) {
+				return energyCapability;
+			}
 		}
 		return super.getCapability(capability, facing);
 	}

--- a/src/main/java/forestry/core/tiles/TileEngine.java
+++ b/src/main/java/forestry/core/tiles/TileEngine.java
@@ -300,15 +300,17 @@ public abstract class TileEngine extends TileBase implements IActivatable, IStre
 
 	@Override
 	public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing) {
-		return energyManager.hasCapability(capability) || super.hasCapability(capability, facing);
+		return (facing == getFacing() && energyManager.hasCapability(capability)) || super.hasCapability(capability, facing);
 	}
 
 	@Override
 	@Nullable
 	public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
-		T energyCapability = energyManager.getCapability(capability);
-		if (energyCapability != null) {
-			return energyCapability;
+		if (facing == getFacing()) {
+			T energyCapability = energyManager.getCapability(capability);
+			if (energyCapability != null) {
+				return energyCapability;
+			}
 		}
 		return super.getCapability(capability, facing);
 	}

--- a/src/main/java/forestry/core/tiles/TileForestry.java
+++ b/src/main/java/forestry/core/tiles/TileForestry.java
@@ -12,6 +12,7 @@ package forestry.core.tiles;
 
 import com.google.common.base.Preconditions;
 
+import forestry.core.config.Constants;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
@@ -57,7 +58,7 @@ import forestry.core.utils.NBTUtilForestry;
 import forestry.core.utils.NetworkUtil;
 import forestry.core.utils.TickHelper;
 
-@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
+@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = Constants.BCLIB_MOD_ID)
 public abstract class TileForestry extends TileEntity implements IStreamable, IErrorLogicSource, ISidedInventory, IFilterSlotDelegate, ITitled, ILocatable, IGuiHandlerTile, ITickable, ITriggerProvider {
 	private final ErrorLogic errorHandler = new ErrorLogic();
 	private final AdjacentTileCache tileCache = new AdjacentTileCache(this);
@@ -177,14 +178,14 @@ public abstract class TileForestry extends TileEntity implements IStreamable, IE
 	}
 
 	/* ITriggerProvider */
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addInternalTriggers(Collection<ITriggerInternal> triggers, IStatementContainer container) { }
 
 	@Override
 	public void addInternalSidedTriggers(Collection<ITriggerInternalSided> triggers, IStatementContainer container, @Nonnull EnumFacing side) { }
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) { }
 

--- a/src/main/java/forestry/core/tiles/TileForestry.java
+++ b/src/main/java/forestry/core/tiles/TileForestry.java
@@ -12,9 +12,6 @@ package forestry.core.tiles;
 
 import com.google.common.base.Preconditions;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
@@ -27,15 +24,25 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
-
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
 
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import java.io.IOException;
+import java.util.Collection;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.ITriggerExternal;
+import buildcraft.api.statements.ITriggerInternal;
+import buildcraft.api.statements.ITriggerInternalSided;
+import buildcraft.api.statements.ITriggerProvider;
 import forestry.api.core.IErrorLogic;
 import forestry.api.core.IErrorLogicSource;
 import forestry.api.core.ILocatable;
@@ -50,8 +57,8 @@ import forestry.core.utils.NBTUtilForestry;
 import forestry.core.utils.NetworkUtil;
 import forestry.core.utils.TickHelper;
 
-//@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
-public abstract class TileForestry extends TileEntity implements IStreamable, IErrorLogicSource, ISidedInventory, IFilterSlotDelegate, ITitled, ILocatable, IGuiHandlerTile, ITickable {
+@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
+public abstract class TileForestry extends TileEntity implements IStreamable, IErrorLogicSource, ISidedInventory, IFilterSlotDelegate, ITitled, ILocatable, IGuiHandlerTile, ITickable, ITriggerProvider {
 	private final ErrorLogic errorHandler = new ErrorLogic();
 	private final AdjacentTileCache tileCache = new AdjacentTileCache(this);
 
@@ -170,18 +177,16 @@ public abstract class TileForestry extends TileEntity implements IStreamable, IE
 	}
 
 	/* ITriggerProvider */
-	// TODO: buildcraft for 1.9
-	//	@Optional.Method(modid = "BuildCraftAPI|statements")
-	//	@Override
-	//	public Collection<ITriggerInternal> getInternalTriggers(IStatementContainer container) {
-	//		return null;
-	//	}
-	//
-	//	@Optional.Method(modid = "BuildCraftAPI|statements")
-	//	@Override
-	//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-	//		return null;
-	//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addInternalTriggers(Collection<ITriggerInternal> triggers, IStatementContainer container) { }
+
+	@Override
+	public void addInternalSidedTriggers(Collection<ITriggerInternalSided> triggers, IStatementContainer container, @Nonnull EnumFacing side) { }
+
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) { }
 
 	// / REDSTONE INFO
 	protected boolean isRedstoneActivated() {

--- a/src/main/java/forestry/core/tiles/TilePowered.java
+++ b/src/main/java/forestry/core/tiles/TilePowered.java
@@ -10,9 +10,18 @@
  ******************************************************************************/
 package forestry.core.tiles;
 
-import javax.annotation.Nullable;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
 import java.io.IOException;
 
+import javax.annotation.Nullable;
+
+import buildcraft.api.tiles.IHasWork;
 import forestry.api.core.IErrorLogic;
 import forestry.core.circuits.ISpeedUpgradable;
 import forestry.core.errors.EnumErrorCode;
@@ -22,14 +31,9 @@ import forestry.core.render.TankRenderInfo;
 import forestry.energy.EnergyHelper;
 import forestry.energy.EnergyManager;
 import forestry.energy.EnergyTransferMode;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
-import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
-//@Optional.Interface(iface = "buildcraft.api.tiles.IHasWork", modid = "BuildCraftAPI|tiles")
-public abstract class TilePowered extends TileBase implements IRenderableTile, ISpeedUpgradable, IStreamableGui {
+@Optional.Interface(iface = "buildcraft.api.tiles.IHasWork", modid = "BuildCraftAPI|tiles")
+public abstract class TilePowered extends TileBase implements IRenderableTile, ISpeedUpgradable, IStreamableGui, IHasWork {
 	private static final int WORK_TICK_INTERVAL = 5; // one Forestry work tick happens every WORK_TICK_INTERVAL game ticks
 
 	private final EnergyManager energyManager;
@@ -88,8 +92,7 @@ public abstract class TilePowered extends TileBase implements IRenderableTile, I
 		return false;
 	}
 
-	// TODO: buildcraft for 1.9
-//	@Override
+	@Override
 	public abstract boolean hasWork();
 
 	@Override

--- a/src/main/java/forestry/core/tiles/TilePowered.java
+++ b/src/main/java/forestry/core/tiles/TilePowered.java
@@ -10,20 +10,10 @@
  ******************************************************************************/
 package forestry.core.tiles;
 
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.EnumFacing;
-import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.fml.common.Optional;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
-import java.io.IOException;
-
-import javax.annotation.Nullable;
-
 import buildcraft.api.tiles.IHasWork;
 import forestry.api.core.IErrorLogic;
 import forestry.core.circuits.ISpeedUpgradable;
+import forestry.core.config.Constants;
 import forestry.core.errors.EnumErrorCode;
 import forestry.core.network.IStreamableGui;
 import forestry.core.network.PacketBufferForestry;
@@ -31,8 +21,17 @@ import forestry.core.render.TankRenderInfo;
 import forestry.energy.EnergyHelper;
 import forestry.energy.EnergyManager;
 import forestry.energy.EnergyTransferMode;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
-@Optional.Interface(iface = "buildcraft.api.tiles.IHasWork", modid = "BuildCraftAPI|tiles")
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+@Optional.Interface(iface = "buildcraft.api.tiles.IHasWork", modid = Constants.BCLIB_MOD_ID)
 public abstract class TilePowered extends TileBase implements IRenderableTile, ISpeedUpgradable, IStreamableGui, IHasWork {
 	private static final int WORK_TICK_INTERVAL = 5; // one Forestry work tick happens every WORK_TICK_INTERVAL game ticks
 

--- a/src/main/java/forestry/core/tiles/TilePowered.java
+++ b/src/main/java/forestry/core/tiles/TilePowered.java
@@ -12,8 +12,8 @@ package forestry.core.tiles;
 
 import buildcraft.api.tiles.IHasWork;
 import forestry.api.core.IErrorLogic;
+import forestry.core.capabilities.HasWorkWrapper;
 import forestry.core.circuits.ISpeedUpgradable;
-import forestry.core.config.Constants;
 import forestry.core.errors.EnumErrorCode;
 import forestry.core.network.IStreamableGui;
 import forestry.core.network.PacketBufferForestry;
@@ -24,15 +24,17 @@ import forestry.energy.EnergyTransferMode;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-@Optional.Interface(iface = "buildcraft.api.tiles.IHasWork", modid = Constants.BCLIB_MOD_ID)
-public abstract class TilePowered extends TileBase implements IRenderableTile, ISpeedUpgradable, IStreamableGui, IHasWork {
+import static forestry.core.capabilities.HasWorkWrapper.CAPABILITY_HAS_WORK;
+
+public abstract class TilePowered extends TileBase implements IRenderableTile, ISpeedUpgradable, IStreamableGui {
+
 	private static final int WORK_TICK_INTERVAL = 5; // one Forestry work tick happens every WORK_TICK_INTERVAL game ticks
 
 	private final EnergyManager energyManager;
@@ -91,7 +93,6 @@ public abstract class TilePowered extends TileBase implements IRenderableTile, I
 		return false;
 	}
 
-	@Override
 	public abstract boolean hasWork();
 
 	@Override
@@ -199,12 +200,14 @@ public abstract class TilePowered extends TileBase implements IRenderableTile, I
 	/* IPowerHandler */
 	@Override
 	public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing) {
+		if (capability == CAPABILITY_HAS_WORK) return true;
 		return energyManager.hasCapability(capability) || super.hasCapability(capability, facing);
 	}
 
 	@Override
 	@Nullable
 	public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
+		if (capability == CAPABILITY_HAS_WORK) return CAPABILITY_HAS_WORK.cast(new HasWorkWrapper(this));
 		T energyCapability = energyManager.getCapability(capability);
 		if (energyCapability != null) {
 			return energyCapability;

--- a/src/main/java/forestry/core/triggers/Sprite.java
+++ b/src/main/java/forestry/core/triggers/Sprite.java
@@ -1,0 +1,30 @@
+package forestry.core.triggers;
+
+import buildcraft.api.core.render.ISprite;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.ResourceLocation;
+
+public class Sprite implements ISprite {
+
+	private final ResourceLocation rl;
+
+	public Sprite(ResourceLocation rl) {
+		this.rl = rl;
+	}
+
+	@Override
+	public void bindTexture() {
+		Minecraft.getMinecraft().getTextureManager().bindTexture(rl);
+	}
+
+	@Override
+	public double getInterpU(double u) {
+		return u;
+	}
+
+	@Override
+	public double getInterpV(double v) {
+		return v;
+	}
+
+}

--- a/src/main/java/forestry/core/triggers/Trigger.java
+++ b/src/main/java/forestry/core/triggers/Trigger.java
@@ -10,21 +10,18 @@
  ******************************************************************************/
 package forestry.core.triggers;
 
-import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
-
-import javax.annotation.Nullable;
-
 import buildcraft.api.core.render.ISprite;
 import buildcraft.api.statements.IStatement;
 import buildcraft.api.statements.IStatementParameter;
 import buildcraft.api.statements.ITriggerExternal;
 import buildcraft.api.statements.StatementManager;
-import buildcraft.lib.client.sprite.SpriteRaw;
-import forestry.Forestry;
 import forestry.core.config.Constants;
 import forestry.core.utils.Translator;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import javax.annotation.Nullable;
 
 public abstract class Trigger implements ITriggerExternal {
 
@@ -32,14 +29,14 @@ public abstract class Trigger implements ITriggerExternal {
 	private final String localization;
 	private final String textureName;
 
-	protected Trigger(String uid) {
-		this(uid, uid);
+	protected Trigger(String uid, String textureName) {
+		this(uid, uid, textureName);
 	}
 
-	protected Trigger(String uid, String localization) {
+	protected Trigger(String uid, String localization, String textureName) {
 		this.uid = "forestry:" + uid;
 		this.localization = localization;
-		this.textureName = localization.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
+		this.textureName = textureName;
 		StatementManager.registerStatement(this);
 	}
 
@@ -76,7 +73,7 @@ public abstract class Trigger implements ITriggerExternal {
 	@Override
 	public ISprite getSprite() {
 		if (icon == null) {
-			icon = new SpriteRaw(new ResourceLocation(Constants.MOD_ID, String.format("textures/gui/triggers/%s.png", textureName)), 0, 0, 16, 16, 16);
+			icon = new Sprite(new ResourceLocation(Constants.MOD_ID, String.format("textures/gui/triggers/%s.png", textureName)));
 		}
 		return icon;
 	}

--- a/src/main/java/forestry/core/triggers/Trigger.java
+++ b/src/main/java/forestry/core/triggers/Trigger.java
@@ -10,62 +10,84 @@
  ******************************************************************************/
 package forestry.core.triggers;
 
-// TODO: buildcraft for 1.9
-public abstract class Trigger {//implements ITriggerExternal {
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
-//	private final String uid;
-//	private final String localization;
+import javax.annotation.Nullable;
 
-//	protected Trigger(String uid) {
-//		this(uid, uid);
-//	}
-//
-//	protected Trigger(String uid, String localization) {
-//		this.uid = "forestry:" + uid;
-//		this.localization = localization;
-//		StatementManager.registerStatement(this);
-//	}
-//
-//	@Override
-//	public String getUniqueTag() {
-//		return uid;
-//	}
-//
-//	@Override
-//	public String getDescription() {
-//		return Translator.translateToLocal("for.trigger." + localization);
-//	}
-//
-//	@Override
-//	public IStatementParameter createParameter(int index) {
-//		return null;
-//	}
-//
-//	@Override
-//	public int maxParameters() {
-//		return 0;
-//	}
-//
-//	@Override
-//	public int minParameters() {
-//		return 0;
-//	}
-//
-//	@SideOnly(Side.CLIENT)
-//	private TextureAtlasSprite icon;
-//
-//	@SideOnly(Side.CLIENT)
-//	public void registerSprites() {
-//		icon = TextureManager.registerSprite("triggers/" + localization);
-//	}
-//
-//	@Override
-//	public TextureAtlasSprite getGuiSprite() {
-//		return icon;
-//	}
-//
-//	@Override
-//	public IStatement rotateLeft() {
-//		return this;
-//	}
+import buildcraft.api.core.render.ISprite;
+import buildcraft.api.statements.IStatement;
+import buildcraft.api.statements.IStatementParameter;
+import buildcraft.api.statements.ITriggerExternal;
+import buildcraft.api.statements.StatementManager;
+import buildcraft.lib.client.sprite.SpriteRaw;
+import forestry.Forestry;
+import forestry.core.config.Constants;
+import forestry.core.utils.Translator;
+
+public abstract class Trigger implements ITriggerExternal {
+
+	private final String uid;
+	private final String localization;
+	private final String textureName;
+
+	protected Trigger(String uid) {
+		this(uid, uid);
+	}
+
+	protected Trigger(String uid, String localization) {
+		this.uid = "forestry:" + uid;
+		this.localization = localization;
+		this.textureName = localization.replaceAll("([a-z])([A-Z])", "$1_$2").toLowerCase();
+		StatementManager.registerStatement(this);
+	}
+
+	@Override
+	public String getUniqueTag() {
+		return uid;
+	}
+
+	@Override
+	public String getDescription() {
+		return Translator.translateToLocal("for.trigger." + localization);
+	}
+
+	@Override
+	public IStatementParameter createParameter(int index) {
+		return null;
+	}
+
+	@Override
+	public int maxParameters() {
+		return 0;
+	}
+
+	@Override
+	public int minParameters() {
+		return 0;
+	}
+
+	@SideOnly(Side.CLIENT)
+	@Nullable
+	private ISprite icon;
+
+	@Nullable
+	@Override
+	public ISprite getSprite() {
+		if (icon == null) {
+			icon = new SpriteRaw(new ResourceLocation(Constants.MOD_ID, String.format("textures/gui/triggers/%s.png", textureName)), 0, 0, 16, 16, 16);
+		}
+		return icon;
+	}
+
+	@Override
+	public IStatement rotateLeft() {
+		return this;
+	}
+
+	@Override
+	public IStatement[] getPossible() {
+		return new IStatement[0];
+	}
 }

--- a/src/main/java/forestry/energy/EnergyHelper.java
+++ b/src/main/java/forestry/energy/EnergyHelper.java
@@ -1,6 +1,7 @@
 package forestry.energy;
 
 import forestry.api.core.ForestryAPI;
+import forestry.core.config.Config;
 import forestry.core.tiles.TileEngine;
 import forestry.energy.compat.mj.MjHelper;
 import forestry.energy.compat.tesla.TeslaHelper;
@@ -73,18 +74,18 @@ public class EnergyHelper {
 			return receptor.getEnergyManager().receiveEnergy(extractable, simulate);
 		}
 
-		if (tile.hasCapability(CapabilityEnergy.ENERGY, side)) {
+		if (Config.enableRF && tile.hasCapability(CapabilityEnergy.ENERGY, side)) {
 			IEnergyStorage energyStorage = tile.getCapability(CapabilityEnergy.ENERGY, side);
 			if (energyStorage != null) {
 				return energyStorage.receiveEnergy(extractable, simulate);
 			}
 		}
 
-		if (TeslaHelper.isEnergyReceiver(tile, side)) {
+		if (Config.enableTesla && TeslaHelper.isEnergyReceiver(tile, side)) {
 			return TeslaHelper.sendEnergy(tile, side, extractable, simulate);
 		}
 
-		if (MjHelper.isEnergyReceiver(tile, side)) {
+		if (Config.enableMJ && MjHelper.isEnergyReceiver(tile, side)) {
 			return MjHelper.sendEnergy(tile, side, extractable, simulate);
 		}
 

--- a/src/main/java/forestry/energy/EnergyHelper.java
+++ b/src/main/java/forestry/energy/EnergyHelper.java
@@ -1,14 +1,15 @@
 package forestry.energy;
 
-import javax.annotation.Nullable;
-
 import forestry.api.core.ForestryAPI;
 import forestry.core.tiles.TileEngine;
+import forestry.energy.compat.mj.MjHelper;
 import forestry.energy.compat.tesla.TeslaHelper;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
+
+import javax.annotation.Nullable;
 
 public class EnergyHelper {
 	public static int scaleForDifficulty(int energyValue) {
@@ -83,6 +84,10 @@ public class EnergyHelper {
 			return TeslaHelper.sendEnergy(tile, side, extractable, simulate);
 		}
 
+		if (MjHelper.isEnergyReceiver(tile, side)) {
+			return MjHelper.sendEnergy(tile, side, extractable, simulate);
+		}
+
 		return 0;
 	}
 
@@ -106,6 +111,7 @@ public class EnergyHelper {
 			return energyStorage != null && energyStorage.canReceive();
 		}
 
-		return TeslaHelper.isEnergyReceiver(tile, side);
+		return TeslaHelper.isEnergyReceiver(tile, side) ||
+				MjHelper.isEnergyReceiver(tile, side);
 	}
 }

--- a/src/main/java/forestry/energy/EnergyManager.java
+++ b/src/main/java/forestry/energy/EnergyManager.java
@@ -138,7 +138,7 @@ public class EnergyManager extends EnergyStorage implements IStreamable, INbtRea
 			} else if (capability == mjReceiver && externalMode.canReceive()) {
 				return mjReceiver.cast(new MjReceiverWrapper(this));
 			} else if (capability == mjRedstoneReceiver && externalMode.canReceive()) {
-				return mjRedstoneReceiver.cast(new MjReceiverWrapper(this));
+				return mjRedstoneReceiver.cast(new MjRedstoneReceiverWrapper(this));
 			} else if (capability == mjReadable) {
 				return mjReadable.cast(new MjReadableWrapper(this));
 			} else if (capability == mjConnector) {

--- a/src/main/java/forestry/energy/EnergyManager.java
+++ b/src/main/java/forestry/energy/EnergyManager.java
@@ -1,13 +1,22 @@
 package forestry.energy;
 
-import buildcraft.api.mj.*;
+import buildcraft.api.mj.IMjConnector;
+import buildcraft.api.mj.IMjPassiveProvider;
+import buildcraft.api.mj.IMjReadable;
+import buildcraft.api.mj.IMjReceiver;
+import buildcraft.api.mj.IMjRedstoneReceiver;
 import forestry.api.core.INbtReadable;
 import forestry.api.core.INbtWritable;
 import forestry.core.config.Config;
 import forestry.core.network.IStreamable;
 import forestry.core.network.PacketBufferForestry;
 import forestry.energy.compat.EnergyStorageWrapper;
-import forestry.energy.compat.mj.*;
+import forestry.energy.compat.mj.MjConnectorWrapper;
+import forestry.energy.compat.mj.MjHelper;
+import forestry.energy.compat.mj.MjPassiveProviderWrapper;
+import forestry.energy.compat.mj.MjReadableWrapper;
+import forestry.energy.compat.mj.MjReceiverWrapper;
+import forestry.energy.compat.mj.MjRedstoneReceiverWrapper;
 import forestry.energy.compat.tesla.TeslaConsumerWrapper;
 import forestry.energy.compat.tesla.TeslaHelper;
 import forestry.energy.compat.tesla.TeslaHolderWrapper;

--- a/src/main/java/forestry/energy/EnergyManager.java
+++ b/src/main/java/forestry/energy/EnergyManager.java
@@ -3,6 +3,7 @@ package forestry.energy;
 import buildcraft.api.mj.*;
 import forestry.api.core.INbtReadable;
 import forestry.api.core.INbtWritable;
+import forestry.core.config.Config;
 import forestry.core.network.IStreamable;
 import forestry.core.network.PacketBufferForestry;
 import forestry.energy.compat.EnergyStorageWrapper;
@@ -98,11 +99,19 @@ public class EnergyManager extends EnergyStorage implements IStreamable, INbtRea
 	}
 
 	public boolean hasCapability(Capability<?> capability) {
-		return capability == CapabilityEnergy.ENERGY ||
-				capability == TeslaHelper.TESLA_PRODUCER && externalMode.canExtract() ||
+		return Config.enableRF && capability == CapabilityEnergy.ENERGY ||
+				Config.enableTesla && hasTeslaCapability(capability) ||
+				Config.enableMJ && hasMjCapability(capability);
+	}
+
+	private boolean hasTeslaCapability(Capability<?> capability) {
+		return capability == TeslaHelper.TESLA_PRODUCER && externalMode.canExtract() ||
 				capability == TeslaHelper.TESLA_CONSUMER && externalMode.canReceive() ||
-				capability == TeslaHelper.TESLA_HOLDER ||
-				capability == MjHelper.CAP_READABLE ||
+				capability == TeslaHelper.TESLA_HOLDER;
+	}
+
+	private boolean hasMjCapability(Capability<?> capability) {
+		return capability == MjHelper.CAP_READABLE ||
 				capability == MjHelper.CAP_CONNECTOR ||
 				capability == MjHelper.CAP_PASSIVE_PROVIDER && externalMode.canExtract() ||
 				capability == MjHelper.CAP_REDSTONE_RECEIVER && externalMode.canReceive() ||
@@ -111,6 +120,7 @@ public class EnergyManager extends EnergyStorage implements IStreamable, INbtRea
 
 	@Nullable
 	public <T> T getCapability(Capability<T> capability) {
+		if (!hasCapability(capability)) return null;
 		if (capability == CapabilityEnergy.ENERGY) {
 			IEnergyStorage energyStorage = new EnergyStorageWrapper(this, externalMode);
 			return CapabilityEnergy.ENERGY.cast(energyStorage);

--- a/src/main/java/forestry/energy/EnergyManager.java
+++ b/src/main/java/forestry/energy/EnergyManager.java
@@ -1,29 +1,28 @@
 package forestry.energy;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.math.MathHelper;
-
-import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.energy.CapabilityEnergy;
-import net.minecraftforge.energy.EnergyStorage;
-import net.minecraftforge.energy.IEnergyStorage;
-
+import buildcraft.api.mj.*;
 import forestry.api.core.INbtReadable;
 import forestry.api.core.INbtWritable;
 import forestry.core.network.IStreamable;
 import forestry.core.network.PacketBufferForestry;
 import forestry.energy.compat.EnergyStorageWrapper;
+import forestry.energy.compat.mj.*;
 import forestry.energy.compat.tesla.TeslaConsumerWrapper;
 import forestry.energy.compat.tesla.TeslaHelper;
 import forestry.energy.compat.tesla.TeslaHolderWrapper;
 import forestry.energy.compat.tesla.TeslaProducerWrapper;
-
 import net.darkhax.tesla.api.ITeslaConsumer;
 import net.darkhax.tesla.api.ITeslaHolder;
 import net.darkhax.tesla.api.ITeslaProducer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.energy.EnergyStorage;
+import net.minecraftforge.energy.IEnergyStorage;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
 
 public class EnergyManager extends EnergyStorage implements IStreamable, INbtReadable, INbtWritable {
 	private EnergyTransferMode externalMode = EnergyTransferMode.BOTH;
@@ -102,7 +101,12 @@ public class EnergyManager extends EnergyStorage implements IStreamable, INbtRea
 		return capability == CapabilityEnergy.ENERGY ||
 				capability == TeslaHelper.TESLA_PRODUCER && externalMode.canExtract() ||
 				capability == TeslaHelper.TESLA_CONSUMER && externalMode.canReceive() ||
-				capability == TeslaHelper.TESLA_HOLDER;
+				capability == TeslaHelper.TESLA_HOLDER ||
+				capability == MjHelper.CAP_READABLE ||
+				capability == MjHelper.CAP_CONNECTOR ||
+				capability == MjHelper.CAP_PASSIVE_PROVIDER && externalMode.canExtract() ||
+				capability == MjHelper.CAP_REDSTONE_RECEIVER && externalMode.canReceive() ||
+				capability == MjHelper.CAP_RECEIVER && externalMode.canReceive();
 	}
 
 	@Nullable
@@ -110,7 +114,7 @@ public class EnergyManager extends EnergyStorage implements IStreamable, INbtRea
 		if (capability == CapabilityEnergy.ENERGY) {
 			IEnergyStorage energyStorage = new EnergyStorageWrapper(this, externalMode);
 			return CapabilityEnergy.ENERGY.cast(energyStorage);
-		} else {
+		} else if (TeslaHelper.isTeslaCapability(capability)) {
 			Capability<ITeslaProducer> teslaProducer = TeslaHelper.TESLA_PRODUCER;
 			Capability<ITeslaConsumer> teslaConsumer = TeslaHelper.TESLA_CONSUMER;
 			Capability<ITeslaHolder> teslaHolder = TeslaHelper.TESLA_HOLDER;
@@ -121,14 +125,31 @@ public class EnergyManager extends EnergyStorage implements IStreamable, INbtRea
 				return teslaConsumer.cast(new TeslaConsumerWrapper(this));
 			} else if (capability == teslaHolder) {
 				return teslaHolder.cast(new TeslaHolderWrapper(this));
-			} else {
-				return null;
+			}
+		} else if (MjHelper.isMjCapability(capability)) {
+			Capability<IMjConnector> mjConnector = MjHelper.CAP_CONNECTOR;
+			Capability<IMjPassiveProvider> mjPassiveProvider = MjHelper.CAP_PASSIVE_PROVIDER;
+			Capability<IMjReadable> mjReadable = MjHelper.CAP_READABLE;
+			Capability<IMjReceiver> mjReceiver = MjHelper.CAP_RECEIVER;
+			Capability<IMjRedstoneReceiver> mjRedstoneReceiver = MjHelper.CAP_REDSTONE_RECEIVER;
+
+			if (capability == mjPassiveProvider && externalMode.canExtract()) {
+				return mjPassiveProvider.cast(new MjPassiveProviderWrapper(this));
+			} else if (capability == mjReceiver && externalMode.canReceive()) {
+				return mjReceiver.cast(new MjReceiverWrapper(this));
+			} else if (capability == mjRedstoneReceiver && externalMode.canReceive()) {
+				return mjRedstoneReceiver.cast(new MjReceiverWrapper(this));
+			} else if (capability == mjReadable) {
+				return mjReadable.cast(new MjReadableWrapper(this));
+			} else if (capability == mjConnector) {
+				return mjConnector.cast(new MjConnectorWrapper(this));
 			}
 		}
+		return null;
 	}
 
-	public int calculateRedstone(){
-		return MathHelper.floor(((float)energy / (float)capacity) * 14.0F) + (energy > 0 ? 1 : 0);
+	public int calculateRedstone() {
+		return MathHelper.floor(((float) energy / (float) capacity) * 14.0F) + (energy > 0 ? 1 : 0);
 	}
 
 }

--- a/src/main/java/forestry/energy/compat/mj/MjConnectorWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjConnectorWrapper.java
@@ -17,6 +17,6 @@ public class MjConnectorWrapper implements IMjConnector {
 
 	@Override
 	public boolean canConnect(@Nonnull IMjConnector other) {
-		return true; // TODO
+		return true;
 	}
 }

--- a/src/main/java/forestry/energy/compat/mj/MjConnectorWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjConnectorWrapper.java
@@ -1,0 +1,22 @@
+package forestry.energy.compat.mj;
+
+import buildcraft.api.mj.IMjConnector;
+import forestry.core.config.Constants;
+import forestry.energy.EnergyManager;
+import net.minecraftforge.fml.common.Optional;
+
+import javax.annotation.Nonnull;
+
+@Optional.Interface(iface = "buildcraft.api.mj.IMjConnector", modid = Constants.BCLIB_MOD_ID)
+public class MjConnectorWrapper implements IMjConnector {
+	protected final EnergyManager energyManager;
+
+	public MjConnectorWrapper(EnergyManager energyManager) {
+		this.energyManager = energyManager;
+	}
+
+	@Override
+	public boolean canConnect(@Nonnull IMjConnector other) {
+		return true; // TODO
+	}
+}

--- a/src/main/java/forestry/energy/compat/mj/MjHelper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjHelper.java
@@ -1,6 +1,11 @@
 package forestry.energy.compat.mj;
 
-import buildcraft.api.mj.*;
+import buildcraft.api.mj.IMjConnector;
+import buildcraft.api.mj.IMjPassiveProvider;
+import buildcraft.api.mj.IMjReadable;
+import buildcraft.api.mj.IMjReceiver;
+import buildcraft.api.mj.IMjRedstoneReceiver;
+import buildcraft.api.mj.MjAPI;
 import forestry.core.config.Constants;
 import forestry.core.utils.Log;
 import net.minecraft.tileentity.TileEntity;

--- a/src/main/java/forestry/energy/compat/mj/MjHelper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjHelper.java
@@ -93,4 +93,12 @@ public class MjHelper {
 	public static int mjToRf(int mj) {
 		return mj * 10;
 	}
+
+	public static long rfToMicro(int rf) {
+		return toMicroJoules(rfToMj(rf));
+	}
+
+	public static int microToRf(long microJoules) {
+		return mjToRf(fromMicroJoules(microJoules));
+	}
 }

--- a/src/main/java/forestry/energy/compat/mj/MjHelper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjHelper.java
@@ -11,6 +11,9 @@ import net.minecraftforge.fml.common.Optional;
 
 import javax.annotation.Nullable;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
 @SuppressWarnings("ConstantConditions")
 public class MjHelper {
 	@Nullable
@@ -64,7 +67,8 @@ public class MjHelper {
 			}
 			return 0;
 		}
-		return fromMicroJoules(amountMicro - consumer.receivePower(amountMicro, simulate));
+		long req = consumer.getPowerRequested();
+		return fromMicroJoules(amountMicro - consumer.receivePower(min(amountMicro, req), simulate) - max(0, amountMicro - req));
 	}
 
 	public static boolean isMjCapability(Capability<?> capability) {

--- a/src/main/java/forestry/energy/compat/mj/MjHelper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjHelper.java
@@ -1,0 +1,92 @@
+package forestry.energy.compat.mj;
+
+import buildcraft.api.mj.*;
+import forestry.core.config.Constants;
+import forestry.core.utils.Log;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.fml.common.Optional;
+
+import javax.annotation.Nullable;
+
+@SuppressWarnings("ConstantConditions")
+public class MjHelper {
+	@Nullable
+	@CapabilityInject(IMjConnector.class)
+	public static Capability<IMjConnector> CAP_CONNECTOR = null;
+
+	@Nullable
+	@CapabilityInject(IMjReceiver.class)
+	public static Capability<IMjReceiver> CAP_RECEIVER = null;
+
+	@Nullable
+	@CapabilityInject(IMjRedstoneReceiver.class)
+	public static Capability<IMjRedstoneReceiver> CAP_REDSTONE_RECEIVER = null;
+
+	@Nullable
+	@CapabilityInject(IMjReadable.class)
+	public static Capability<IMjReadable> CAP_READABLE = null;
+
+	@Nullable
+	@CapabilityInject(IMjPassiveProvider.class)
+	public static Capability<IMjPassiveProvider> CAP_PASSIVE_PROVIDER = null;
+
+	public static boolean isLoaded() {
+		return CAP_CONNECTOR != null && CAP_RECEIVER != null && CAP_REDSTONE_RECEIVER != null && CAP_READABLE != null && CAP_PASSIVE_PROVIDER != null;
+	}
+
+	public static boolean isEnergyReceiver(TileEntity tile, EnumFacing side) {
+		return isLoaded() && _isEnergyReceiver(tile, side);
+	}
+
+	public static int sendEnergy(TileEntity tile, EnumFacing side, int amount, boolean simulate) {
+		if (isLoaded()) {
+			return mjToRf(_sendEnergy(tile, side, rfToMj(amount), simulate));
+		} else {
+			return 0;
+		}
+	}
+
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
+	private static boolean _isEnergyReceiver(TileEntity tile, EnumFacing side) {
+		return CAP_RECEIVER != null && tile.hasCapability(CAP_RECEIVER, side);
+	}
+
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
+	private static int _sendEnergy(TileEntity tile, EnumFacing side, int amount, boolean simulate) {
+		long amountMicro = toMicroJoules(amount);
+		IMjReceiver consumer = tile.getCapability(CAP_RECEIVER, side);
+		if (consumer == null) {
+			if (tile.hasCapability(CAP_RECEIVER, side)) {
+				Log.error("Tile claims to support MJ but does not have the capability. {} {}", tile.getPos(), tile);
+			}
+			return 0;
+		}
+		return fromMicroJoules(amountMicro - consumer.receivePower(amountMicro, simulate));
+	}
+
+	public static boolean isMjCapability(Capability<?> capability) {
+		if (!isLoaded()) return false;
+
+		return capability == CAP_CONNECTOR || capability == CAP_RECEIVER || capability == CAP_REDSTONE_RECEIVER ||
+				capability == CAP_READABLE || capability == CAP_PASSIVE_PROVIDER;
+	}
+
+	public static int fromMicroJoules(long microJoules) {
+		return (int) (microJoules / MjAPI.MJ);
+	}
+
+	public static long toMicroJoules(long mj) {
+		return mj * MjAPI.MJ;
+	}
+
+	public static int rfToMj(int rf) {
+		return rf / 10;
+	}
+
+	public static int mjToRf(int mj) {
+		return mj * 10;
+	}
+}

--- a/src/main/java/forestry/energy/compat/mj/MjPassiveProviderWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjPassiveProviderWrapper.java
@@ -1,0 +1,22 @@
+package forestry.energy.compat.mj;
+
+import buildcraft.api.mj.IMjPassiveProvider;
+import buildcraft.api.mj.IMjReadable;
+import forestry.core.config.Constants;
+import forestry.energy.EnergyManager;
+import net.minecraftforge.fml.common.Optional;
+
+@Optional.Interface(iface = "buildcraft.api.mj.IMjPassiveProvider", modid = Constants.BCLIB_MOD_ID)
+public class MjPassiveProviderWrapper extends MjConnectorWrapper implements IMjPassiveProvider {
+	public MjPassiveProviderWrapper(EnergyManager energyManager) {
+		super(energyManager);
+	}
+
+	@Override
+	public long extractPower(long min, long max, boolean simulate) {
+		int max1 = MjHelper.mjToRf(MjHelper.fromMicroJoules(max));
+		int actualMin = energyManager.extractEnergy(max1, true);
+		if (actualMin < min) return 0;
+		return MjHelper.toMicroJoules(MjHelper.rfToMj(energyManager.extractEnergy(max1, simulate)));
+	}
+}

--- a/src/main/java/forestry/energy/compat/mj/MjPassiveProviderWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjPassiveProviderWrapper.java
@@ -14,9 +14,9 @@ public class MjPassiveProviderWrapper extends MjConnectorWrapper implements IMjP
 
 	@Override
 	public long extractPower(long min, long max, boolean simulate) {
-		int max1 = MjHelper.mjToRf(MjHelper.fromMicroJoules(max));
+		int max1 = MjHelper.microToRf(max);
 		int actualMin = energyManager.extractEnergy(max1, true);
 		if (actualMin < min) return 0;
-		return MjHelper.toMicroJoules(MjHelper.rfToMj(energyManager.extractEnergy(max1, simulate)));
+		return MjHelper.rfToMicro(energyManager.extractEnergy(max1, simulate));
 	}
 }

--- a/src/main/java/forestry/energy/compat/mj/MjReadableWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjReadableWrapper.java
@@ -13,11 +13,11 @@ public class MjReadableWrapper extends MjConnectorWrapper implements IMjReadable
 
 	@Override
 	public long getStored() {
-		return MjHelper.toMicroJoules(MjHelper.rfToMj(energyManager.getEnergyStored()));
+		return MjHelper.rfToMicro(energyManager.getEnergyStored());
 	}
 
 	@Override
 	public long getCapacity() {
-		return MjHelper.toMicroJoules(MjHelper.rfToMj(energyManager.getMaxEnergyStored()));
+		return MjHelper.rfToMicro(energyManager.getMaxEnergyStored());
 	}
 }

--- a/src/main/java/forestry/energy/compat/mj/MjReadableWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjReadableWrapper.java
@@ -1,0 +1,23 @@
+package forestry.energy.compat.mj;
+
+import buildcraft.api.mj.IMjReadable;
+import forestry.core.config.Constants;
+import forestry.energy.EnergyManager;
+import net.minecraftforge.fml.common.Optional;
+
+@Optional.Interface(iface = "buildcraft.api.mj.IMjReadable", modid = Constants.BCLIB_MOD_ID)
+public class MjReadableWrapper extends MjConnectorWrapper implements IMjReadable {
+	public MjReadableWrapper(EnergyManager energyManager) {
+		super(energyManager);
+	}
+
+	@Override
+	public long getStored() {
+		return MjHelper.toMicroJoules(MjHelper.rfToMj(energyManager.getEnergyStored()));
+	}
+
+	@Override
+	public long getCapacity() {
+		return MjHelper.toMicroJoules(MjHelper.rfToMj(energyManager.getMaxEnergyStored()));
+	}
+}

--- a/src/main/java/forestry/energy/compat/mj/MjReceiverWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjReceiverWrapper.java
@@ -6,6 +6,8 @@ import forestry.core.config.Constants;
 import forestry.energy.EnergyManager;
 import net.minecraftforge.fml.common.Optional;
 
+import static java.lang.Math.min;
+
 @Optional.Interface(iface = "buildcraft.api.mj.IMjReceiver", modid = Constants.BCLIB_MOD_ID)
 public class MjReceiverWrapper extends MjConnectorWrapper implements IMjReceiver, IMjRedstoneReceiver {
 	public MjReceiverWrapper(EnergyManager energyManager) {
@@ -14,11 +16,11 @@ public class MjReceiverWrapper extends MjConnectorWrapper implements IMjReceiver
 
 	@Override
 	public long getPowerRequested() {
-		return MjHelper.toMicroJoules(energyManager.getMaxEnergyReceived());
+		return MjHelper.toMicroJoules(min(energyManager.getMaxEnergyReceived(), energyManager.getMaxEnergyStored() - energyManager.getEnergyStored()));
 	}
 
 	@Override
 	public long receivePower(long microJoules, boolean simulate) {
-		return MjHelper.toMicroJoules(energyManager.receiveEnergy(MjHelper.fromMicroJoules(microJoules), simulate));
+		return microJoules - MjHelper.toMicroJoules(energyManager.receiveEnergy(MjHelper.fromMicroJoules(microJoules), simulate));
 	}
 }

--- a/src/main/java/forestry/energy/compat/mj/MjReceiverWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjReceiverWrapper.java
@@ -1,0 +1,24 @@
+package forestry.energy.compat.mj;
+
+import buildcraft.api.mj.IMjReceiver;
+import buildcraft.api.mj.IMjRedstoneReceiver;
+import forestry.core.config.Constants;
+import forestry.energy.EnergyManager;
+import net.minecraftforge.fml.common.Optional;
+
+@Optional.Interface(iface = "buildcraft.api.mj.IMjReceiver", modid = Constants.BCLIB_MOD_ID)
+public class MjReceiverWrapper extends MjConnectorWrapper implements IMjReceiver, IMjRedstoneReceiver {
+	public MjReceiverWrapper(EnergyManager energyManager) {
+		super(energyManager);
+	}
+
+	@Override
+	public long getPowerRequested() {
+		return MjHelper.toMicroJoules(energyManager.getMaxEnergyReceived());
+	}
+
+	@Override
+	public long receivePower(long microJoules, boolean simulate) {
+		return MjHelper.toMicroJoules(energyManager.receiveEnergy(MjHelper.fromMicroJoules(microJoules), simulate));
+	}
+}

--- a/src/main/java/forestry/energy/compat/mj/MjRedstoneReceiverWrapper.java
+++ b/src/main/java/forestry/energy/compat/mj/MjRedstoneReceiverWrapper.java
@@ -1,15 +1,15 @@
 package forestry.energy.compat.mj;
 
-import buildcraft.api.mj.IMjReceiver;
+import buildcraft.api.mj.IMjRedstoneReceiver;
 import forestry.core.config.Constants;
 import forestry.energy.EnergyManager;
 import net.minecraftforge.fml.common.Optional;
 
 import static java.lang.Math.min;
 
-@Optional.Interface(iface = "buildcraft.api.mj.IMjReceiver", modid = Constants.BCLIB_MOD_ID)
-public class MjReceiverWrapper extends MjConnectorWrapper implements IMjReceiver {
-	public MjReceiverWrapper(EnergyManager energyManager) {
+@Optional.Interface(iface = "buildcraft.api.mj.IMjRedstoneReceiver", modid = Constants.BCLIB_MOD_ID)
+public class MjRedstoneReceiverWrapper extends MjConnectorWrapper implements IMjRedstoneReceiver {
+	public MjRedstoneReceiverWrapper(EnergyManager energyManager) {
 		super(energyManager);
 	}
 

--- a/src/main/java/forestry/energy/compat/mj/package-info.java
+++ b/src/main/java/forestry/energy/compat/mj/package-info.java
@@ -1,0 +1,9 @@
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+package forestry.energy.compat.mj;
+
+import forestry.core.utils.FieldsAreNonnullByDefault;
+import mcp.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/java/forestry/energy/compat/tesla/TeslaHelper.java
+++ b/src/main/java/forestry/energy/compat/tesla/TeslaHelper.java
@@ -1,7 +1,5 @@
 package forestry.energy.compat.tesla;
 
-import javax.annotation.Nullable;
-
 import forestry.core.config.Constants;
 import forestry.core.utils.Log;
 import net.darkhax.tesla.api.ITeslaConsumer;
@@ -12,6 +10,8 @@ import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.fml.common.Optional;
+
+import javax.annotation.Nullable;
 
 public class TeslaHelper {
 	@Nullable
@@ -57,5 +57,10 @@ public class TeslaHelper {
 			return 0;
 		}
 		return (int) consumer.givePower(amount, simulate);
+	}
+
+	public static boolean isTeslaCapability(Capability<?> capability) {
+		if (!isLoaded()) return false;
+		return capability == TESLA_CONSUMER || capability == TESLA_HOLDER || capability == TESLA_PRODUCER;
 	}
 }

--- a/src/main/java/forestry/energy/gui/GuiEngine.java
+++ b/src/main/java/forestry/energy/gui/GuiEngine.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.energy.gui;
 
+import forestry.core.config.Config;
 import net.minecraft.inventory.Container;
 
 import forestry.core.gui.GuiForestryTitled;
@@ -49,10 +50,10 @@ public abstract class GuiEngine<C extends Container, I extends TileEngine> exten
 			drawHeader(Translator.translateToLocal("for.gui.energy"), x + 22, y + 8);
 
 			drawSubheader(Translator.translateToLocal("for.gui.currentOutput") + ':', x + 22, y + 20);
-			drawText(tile.getCurrentOutput() + " RF/t", x + 22, y + 32);
+			drawText(Config.energyDisplayMode.formatRate(tile.getCurrentOutput()), x + 22, y + 32);
 
 			drawSubheader(Translator.translateToLocal("for.gui.stored") + ':', x + 22, y + 44);
-			drawText(tile.getEnergyManager().getEnergyStored() + " RF", x + 22, y + 56);
+			drawText(Config.energyDisplayMode.formatEnergyValue(tile.getEnergyManager().getEnergyStored()), x + 22, y + 56);
 
 			drawSubheader(Translator.translateToLocal("for.gui.heat") + ':', x + 22, y + 68);
 			drawText((double) tile.getHeat() / (double) 10 + 20.0 + " C", x + 22, y + 80);
@@ -60,7 +61,7 @@ public abstract class GuiEngine<C extends Container, I extends TileEngine> exten
 
 		@Override
 		public String getTooltip() {
-			return tile.getCurrentOutput() + " RF/t";
+			return Config.energyDisplayMode.formatRate(tile.getCurrentOutput());
 		}
 	}
 

--- a/src/main/java/forestry/energy/tiles/TileEnginePeat.java
+++ b/src/main/java/forestry/energy/tiles/TileEnginePeat.java
@@ -10,9 +10,6 @@
  ******************************************************************************/
 package forestry.energy.tiles;
 
-import java.io.IOException;
-import java.util.Collection;
-
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -20,14 +17,20 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import java.io.IOException;
+import java.util.Collection;
 
+import javax.annotation.Nonnull;
+
+import buildcraft.api.statements.ITriggerExternal;
 import forestry.api.fuels.FuelManager;
 import forestry.core.ModuleCore;
 import forestry.core.blocks.BlockBase;
@@ -43,6 +46,7 @@ import forestry.core.utils.InventoryUtil;
 import forestry.energy.gui.ContainerEnginePeat;
 import forestry.energy.gui.GuiEnginePeat;
 import forestry.energy.inventory.InventoryEnginePeat;
+import forestry.factory.triggers.FactoryTriggers;
 
 public class TileEnginePeat extends TileEngine implements ISidedInventory {
 	private ItemStack fuel = ItemStack.EMPTY;
@@ -310,15 +314,13 @@ public class TileEnginePeat extends TileEngine implements ISidedInventory {
 	}
 
 	/* ITriggerProvider */
-	// TODO: buildcraft for 1.9
-	//	@Optional.Method(modid = "BuildCraftAPI|statements")
-	//	@Override
-	//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-	//		LinkedList<ITriggerExternal> res = new LinkedList<>();
-	//		res.add(FactoryTriggers.lowFuel25);
-	//		res.add(FactoryTriggers.lowFuel10);
-	//		return res;
-	//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		super.addExternalTriggers(triggers, side, tile);
+		triggers.add(FactoryTriggers.lowFuel25);
+		triggers.add(FactoryTriggers.lowFuel10);
+	}
 
 	@Override
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/forestry/energy/tiles/TileEnginePeat.java
+++ b/src/main/java/forestry/energy/tiles/TileEnginePeat.java
@@ -314,7 +314,7 @@ public class TileEnginePeat extends TileEngine implements ISidedInventory {
 	}
 
 	/* ITriggerProvider */
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		super.addExternalTriggers(triggers, side, tile);

--- a/src/main/java/forestry/factory/tiles/TileBottler.java
+++ b/src/main/java/forestry/factory/tiles/TileBottler.java
@@ -10,10 +10,13 @@
  ******************************************************************************/
 package forestry.factory.tiles;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.EnumMap;
 
+import buildcraft.api.statements.ITriggerExternal;
 import forestry.api.core.IErrorLogic;
 import forestry.core.config.Constants;
 import forestry.core.errors.EnumErrorCode;
@@ -31,12 +34,15 @@ import forestry.factory.gui.ContainerBottler;
 import forestry.factory.gui.GuiBottler;
 import forestry.factory.inventory.InventoryBottler;
 import forestry.factory.recipes.BottlerRecipe;
+import forestry.factory.triggers.FactoryTriggers;
+
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -47,6 +53,7 @@ import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidTankProperties;
+import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -356,15 +363,13 @@ public class TileBottler extends TilePowered implements ISidedInventory, ILiquid
 	}
 
 	/* ITRIGGERPROVIDER */
-	// TODO: BuildCraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		LinkedList<ITriggerExternal> res = new LinkedList<>();
-//		res.add(FactoryTriggers.lowResource25);
-//		res.add(FactoryTriggers.lowResource10);
-//		return res;
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		super.addExternalTriggers(triggers, side, tile);
+		triggers.add(FactoryTriggers.lowResource25);
+		triggers.add(FactoryTriggers.lowResource10);
+	}
 
 	@Override
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/forestry/factory/tiles/TileBottler.java
+++ b/src/main/java/forestry/factory/tiles/TileBottler.java
@@ -363,7 +363,7 @@ public class TileBottler extends TilePowered implements ISidedInventory, ILiquid
 	}
 
 	/* ITRIGGERPROVIDER */
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		super.addExternalTriggers(triggers, side, tile);

--- a/src/main/java/forestry/factory/tiles/TileCentrifuge.java
+++ b/src/main/java/forestry/factory/tiles/TileCentrifuge.java
@@ -215,7 +215,7 @@ public class TileCentrifuge extends TilePowered implements ISocketable, ISidedIn
 	}
 
 	/* ITRIGGERPROVIDER */
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		super.addExternalTriggers(triggers, side, tile);

--- a/src/main/java/forestry/factory/tiles/TileCentrifuge.java
+++ b/src/main/java/forestry/factory/tiles/TileCentrifuge.java
@@ -10,11 +10,29 @@
  ******************************************************************************/
 package forestry.factory.tiles;
 
-import javax.annotation.Nullable;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.inventory.InventoryCraftResult;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Stack;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import buildcraft.api.statements.ITriggerExternal;
 import forestry.api.circuits.ChipsetManager;
 import forestry.api.circuits.CircuitSocketType;
 import forestry.api.circuits.ICircuitBoard;
@@ -34,17 +52,7 @@ import forestry.factory.gui.ContainerCentrifuge;
 import forestry.factory.gui.GuiCentrifuge;
 import forestry.factory.inventory.InventoryCentrifuge;
 import forestry.factory.recipes.CentrifugeRecipeManager;
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.inventory.Container;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.inventory.ISidedInventory;
-import net.minecraft.inventory.InventoryCraftResult;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.nbt.NBTTagList;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import forestry.factory.triggers.FactoryTriggers;
 
 public class TileCentrifuge extends TilePowered implements ISocketable, ISidedInventory, IItemStackDisplay {
 	private static final int TICKS_PER_RECIPE_TIME = 1;
@@ -207,15 +215,13 @@ public class TileCentrifuge extends TilePowered implements ISocketable, ISidedIn
 	}
 
 	/* ITRIGGERPROVIDER */
-	// TODO: BuildCraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		LinkedList<ITriggerExternal> res = new LinkedList<>();
-//		res.add(FactoryTriggers.lowResource25);
-//		res.add(FactoryTriggers.lowResource10);
-//		return res;
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		super.addExternalTriggers(triggers, side, tile);
+		triggers.add(FactoryTriggers.lowResource25);
+		triggers.add(FactoryTriggers.lowResource10);
+	}
 
 	/* ISocketable */
 	@Override

--- a/src/main/java/forestry/factory/tiles/TileFermenter.java
+++ b/src/main/java/forestry/factory/tiles/TileFermenter.java
@@ -10,9 +10,6 @@
  ******************************************************************************/
 package forestry.factory.tiles;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
-
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -20,15 +17,23 @@ import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import java.io.IOException;
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import buildcraft.api.statements.ITriggerExternal;
 import forestry.api.core.IErrorLogic;
 import forestry.api.fuels.FermenterFuel;
 import forestry.api.fuels.FuelManager;
@@ -47,6 +52,7 @@ import forestry.factory.gui.ContainerFermenter;
 import forestry.factory.gui.GuiFermenter;
 import forestry.factory.inventory.InventoryFermenter;
 import forestry.factory.recipes.FermenterRecipeManager;
+import forestry.factory.triggers.FactoryTriggers;
 
 public class TileFermenter extends TilePowered implements ISidedInventory, ILiquidTankTile {
 	private final FilteredTank resourceTank;
@@ -306,15 +312,13 @@ public class TileFermenter extends TilePowered implements ISidedInventory, ILiqu
 	}
 
 	/* ITRIGGERPROVIDER */
-	// TODO: BuildCraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		LinkedList<ITriggerExternal> res = new LinkedList<>();
-//		res.add(FactoryTriggers.lowResource25);
-//		res.add(FactoryTriggers.lowResource10);
-//		return res;
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		super.addExternalTriggers(triggers, side, tile);
+		triggers.add(FactoryTriggers.lowResource25);
+		triggers.add(FactoryTriggers.lowResource10);
+	}
 
 	@Override
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/forestry/factory/tiles/TileFermenter.java
+++ b/src/main/java/forestry/factory/tiles/TileFermenter.java
@@ -312,7 +312,7 @@ public class TileFermenter extends TilePowered implements ISidedInventory, ILiqu
 	}
 
 	/* ITRIGGERPROVIDER */
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		super.addExternalTriggers(triggers, side, tile);

--- a/src/main/java/forestry/factory/triggers/FactoryTriggers.java
+++ b/src/main/java/forestry/factory/triggers/FactoryTriggers.java
@@ -10,16 +10,18 @@
  ******************************************************************************/
 package forestry.factory.triggers;
 
+import forestry.core.triggers.Trigger;
+
 public class FactoryTriggers {
-//	public static Trigger lowResource25;
-//	public static Trigger lowResource10;
-//	public static Trigger lowFuel25;
-//	public static Trigger lowFuel10;
-//
-//	public static void initialize() {
-//		lowResource25 = new TriggerLowResource("lowResources.25", 0.25f);
-//		lowResource10 = new TriggerLowResource("lowResources.10", 0.1f);
-//		lowFuel25 = new TriggerLowFuel("lowFuel.25", 0.25f);
-//		lowFuel10 = new TriggerLowFuel("lowFuel.10", 0.1f);
-//	}
+	public static Trigger lowResource25;
+	public static Trigger lowResource10;
+	public static Trigger lowFuel25;
+	public static Trigger lowFuel10;
+
+	public static void initialize() {
+		lowResource25 = new TriggerLowResource("lowResources.25", 0.25f);
+		lowResource10 = new TriggerLowResource("lowResources.10", 0.1f);
+		lowFuel25 = new TriggerLowFuel("lowFuel.25", 0.25f);
+		lowFuel10 = new TriggerLowFuel("lowFuel.10", 0.1f);
+	}
 }

--- a/src/main/java/forestry/factory/triggers/TriggerLowFuel.java
+++ b/src/main/java/forestry/factory/triggers/TriggerLowFuel.java
@@ -10,39 +10,45 @@
  ******************************************************************************/
 package forestry.factory.triggers;
 
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.tiles.TileEngine;
+import forestry.core.tiles.TilePowered;
 import forestry.core.triggers.Trigger;
 
-// TODO: BuildCraft for 1.9
 public class TriggerLowFuel extends Trigger {
 
 	private float threshold = 0.25F;
 
 	public TriggerLowFuel(String uid, float threshold) {
-//		super(uid, "lowFuel");
+		super(uid, "lowFuel");
 		this.threshold = threshold;
 	}
 
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold * 100 + "%";
-//	}
-//
-//	/**
-//	 * Return true if the tile given in parameter activates the trigger, given the parameters.
-//	 */
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (tile instanceof TilePowered) {
-//			return !((TilePowered) tile).hasFuelMin(threshold);
-//		}
-//
-//		if (tile instanceof TileEngine) {
-//			TileEngine tileEngine = (TileEngine) tile;
-//			return !tileEngine.hasFuelMin(threshold);
-//		}
-//
-//		return false;
-//	}
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold * 100 + "%";
+	}
+
+	/**
+	 * Return true if the tile given in parameter activates the trigger, given the parameters.
+	 */
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+
+		if (tile instanceof TilePowered) {
+			return !((TilePowered) tile).hasFuelMin(threshold);
+		}
+
+		if (tile instanceof TileEngine) {
+			TileEngine tileEngine = (TileEngine) tile;
+			return !tileEngine.hasFuelMin(threshold);
+		}
+
+		return false;
+	}
 
 }

--- a/src/main/java/forestry/factory/triggers/TriggerLowFuel.java
+++ b/src/main/java/forestry/factory/triggers/TriggerLowFuel.java
@@ -24,7 +24,7 @@ public class TriggerLowFuel extends Trigger {
 	private float threshold = 0.25F;
 
 	public TriggerLowFuel(String uid, float threshold) {
-		super(uid, "lowFuel");
+		super(uid, "lowFuel", "low_fuel");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/factory/triggers/TriggerLowResource.java
+++ b/src/main/java/forestry/factory/triggers/TriggerLowResource.java
@@ -23,7 +23,7 @@ public class TriggerLowResource extends Trigger {
 	private float threshold = 0.25F;
 
 	public TriggerLowResource(String tag, float threshold) {
-		super(tag, "lowResources");
+		super(tag, "lowResources", "low_resources");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/factory/triggers/TriggerLowResource.java
+++ b/src/main/java/forestry/factory/triggers/TriggerLowResource.java
@@ -10,33 +10,38 @@
  ******************************************************************************/
 package forestry.factory.triggers;
 
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.tiles.TilePowered;
 import forestry.core.triggers.Trigger;
 
-// TODO: BuildCraft for 1.9
 public class TriggerLowResource extends Trigger {
 
 	private float threshold = 0.25F;
 
 	public TriggerLowResource(String tag, float threshold) {
-//		super(tag, "lowResources");
+		super(tag, "lowResources");
 		this.threshold = threshold;
 	}
 
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold * 100 + "%";
-//	}
-//
-//	/**
-//	 * Return true if the tile given in parameter activates the trigger, given the parameters.
-//	 */
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//		if (!(tile instanceof TilePowered)) {
-//			return false;
-//		}
-//
-//		return !((TilePowered) tile).hasResourcesMin(threshold);
-//	}
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold * 100 + "%";
+	}
+
+	/**
+	 * Return true if the tile given in parameter activates the trigger, given the parameters.
+	 */
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+		if (!(tile instanceof TilePowered)) {
+			return false;
+		}
+
+		return !((TilePowered) tile).hasResourcesMin(threshold);
+	}
 
 }

--- a/src/main/java/forestry/farming/tiles/TileFarmHatch.java
+++ b/src/main/java/forestry/farming/tiles/TileFarmHatch.java
@@ -19,6 +19,7 @@ import buildcraft.api.statements.ITriggerInternal;
 import buildcraft.api.statements.ITriggerInternalSided;
 import buildcraft.api.statements.ITriggerProvider;
 import forestry.api.multiblock.IFarmComponent;
+import forestry.core.config.Constants;
 import forestry.core.inventory.AdjacentInventoryCache;
 import forestry.core.tiles.AdjacentTileCache;
 import forestry.core.utils.InventoryUtil;
@@ -38,7 +39,7 @@ import net.minecraftforge.items.wrapper.SidedInvWrapper;
 import java.util.Collection;
 import java.util.Collections;
 
-@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
+@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = Constants.BCLIB_MOD_ID)
 public class TileFarmHatch extends TileFarm implements ISidedInventory, IFarmComponent.Active, ITriggerProvider {
 
 	private static final EnumFacing[] dumpDirections = new EnumFacing[]{EnumFacing.DOWN};
@@ -88,16 +89,16 @@ public class TileFarmHatch extends TileFarm implements ISidedInventory, IFarmCom
 		return super.getCapability(capability, facing);
 	}
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addInternalTriggers(Collection<ITriggerInternal> triggers, IStatementContainer container) { }
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addInternalSidedTriggers(Collection<ITriggerInternalSided> triggers, IStatementContainer container, @Nonnull EnumFacing side) { }
 
 	/* ITRIGGERPROVIDER */
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		if (getMultiblockLogic().isConnected()) {

--- a/src/main/java/forestry/farming/tiles/TileFarmHatch.java
+++ b/src/main/java/forestry/farming/tiles/TileFarmHatch.java
@@ -10,24 +10,36 @@
  ******************************************************************************/
 package forestry.farming.tiles;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.ITriggerExternal;
+import buildcraft.api.statements.ITriggerInternal;
+import buildcraft.api.statements.ITriggerInternalSided;
+import buildcraft.api.statements.ITriggerProvider;
 import forestry.api.multiblock.IFarmComponent;
 import forestry.core.inventory.AdjacentInventoryCache;
 import forestry.core.tiles.AdjacentTileCache;
 import forestry.core.utils.InventoryUtil;
+import forestry.farming.triggers.FarmingTriggers;
+
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import net.minecraftforge.items.wrapper.SidedInvWrapper;
 
-// TODO: Buildcraft for 1.9
-//@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
-public class TileFarmHatch extends TileFarm implements ISidedInventory, IFarmComponent.Active {
+import java.util.Collection;
+import java.util.Collections;
+
+@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
+public class TileFarmHatch extends TileFarm implements ISidedInventory, IFarmComponent.Active, ITriggerProvider {
 
 	private static final EnumFacing[] dumpDirections = new EnumFacing[]{EnumFacing.DOWN};
 
@@ -76,22 +88,20 @@ public class TileFarmHatch extends TileFarm implements ISidedInventory, IFarmCom
 		return super.getCapability(capability, facing);
 	}
 
-	// TODO: Buildcraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerInternal> getInternalTriggers(IStatementContainer container) {
-//		return Collections.emptyList();
-//	}
-//
-//	/* ITRIGGERPROVIDER */
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		if (!getMultiblockLogic().isConnected()) {
-//			return Collections.emptyList();
-//		}
-//
-//		return FarmingTriggers.allExternalTriggers;
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addInternalTriggers(Collection<ITriggerInternal> triggers, IStatementContainer container) { }
 
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addInternalSidedTriggers(Collection<ITriggerInternalSided> triggers, IStatementContainer container, @Nonnull EnumFacing side) { }
+
+	/* ITRIGGERPROVIDER */
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		if (getMultiblockLogic().isConnected()) {
+			triggers.addAll(FarmingTriggers.allExternalTriggers);
+		}
+	}
 }

--- a/src/main/java/forestry/farming/triggers/FarmingTriggers.java
+++ b/src/main/java/forestry/farming/triggers/FarmingTriggers.java
@@ -10,30 +10,35 @@
  ******************************************************************************/
 package forestry.farming.triggers;
 
-// TODO: Buildcraft for 1.9
+import java.util.Arrays;
+import java.util.List;
+
+import buildcraft.api.statements.ITriggerExternal;
+import forestry.core.triggers.Trigger;
+
 public class FarmingTriggers {
-//	public static Trigger lowResourceLiquid50;
-//	public static Trigger lowResourceLiquid25;
-//	public static Trigger lowSoil128;
-//	public static Trigger lowSoil64;
-//	public static Trigger lowSoil32;
-//	public static Trigger lowFertilizer50;
-//	public static Trigger lowFertilizer25;
-//	public static Trigger lowGermlings25;
-//	public static Trigger lowGermlings10;
-//	public static List<ITriggerExternal> allExternalTriggers;
+	public static Trigger lowResourceLiquid50;
+	public static Trigger lowResourceLiquid25;
+	public static Trigger lowSoil128;
+	public static Trigger lowSoil64;
+	public static Trigger lowSoil32;
+	public static Trigger lowFertilizer50;
+	public static Trigger lowFertilizer25;
+	public static Trigger lowGermlings25;
+	public static Trigger lowGermlings10;
+	public static List<ITriggerExternal> allExternalTriggers;
 
 	public static void initialize() {
-//		allExternalTriggers = Arrays.asList(
-//				lowResourceLiquid50 = new TriggerLowLiquid("lowLiquid.50", 0.5f),
-//				lowResourceLiquid25 = new TriggerLowLiquid("lowLiquid.25", 0.25f),
-//				lowSoil128 = new TriggerLowSoil(128),
-//				lowSoil64 = new TriggerLowSoil(64),
-//				lowSoil32 = new TriggerLowSoil(32),
-//				lowFertilizer50 = new TriggerLowFertilizer("lowFertilizer.50", 0.5f),
-//				lowFertilizer25 = new TriggerLowFertilizer("lowFertilizer.25", 0.25f),
-//				lowGermlings25 = new TriggerLowGermlings("lowGermlings.25", 0.25f),
-//				lowGermlings10 = new TriggerLowGermlings("lowGermlings.10", 0.1f)
-//		);
+		allExternalTriggers = Arrays.asList(
+				lowResourceLiquid50 = new TriggerLowLiquid("lowLiquid.50", 0.5f),
+				lowResourceLiquid25 = new TriggerLowLiquid("lowLiquid.25", 0.25f),
+				lowSoil128 = new TriggerLowSoil(128),
+				lowSoil64 = new TriggerLowSoil(64),
+				lowSoil32 = new TriggerLowSoil(32),
+				lowFertilizer50 = new TriggerLowFertilizer("lowFertilizer.50", 0.5f),
+				lowFertilizer25 = new TriggerLowFertilizer("lowFertilizer.25", 0.25f),
+				lowGermlings25 = new TriggerLowGermlings("lowGermlings.25", 0.25f),
+				lowGermlings10 = new TriggerLowGermlings("lowGermlings.10", 0.1f)
+		);
 	}
 }

--- a/src/main/java/forestry/farming/triggers/TriggerLowFertilizer.java
+++ b/src/main/java/forestry/farming/triggers/TriggerLowFertilizer.java
@@ -25,7 +25,7 @@ public class TriggerLowFertilizer extends Trigger {
 	private final float threshold;
 
 	public TriggerLowFertilizer(String tag, float threshold) {
-		super(tag, "lowFertilizer");
+		super(tag, "lowFertilizer", "low_fertilizer");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/farming/triggers/TriggerLowFertilizer.java
+++ b/src/main/java/forestry/farming/triggers/TriggerLowFertilizer.java
@@ -10,29 +10,38 @@
  ******************************************************************************/
 package forestry.farming.triggers;
 
-// TODO: Buildcraft for 1.9
-public class TriggerLowFertilizer {//} extends Trigger {
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-//	private final float threshold;
-//
-//	public TriggerLowFertilizer(String tag, float threshold) {
-//		super(tag, "lowFertilizer");
-//		this.threshold = threshold;
-//	}
-//
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold * 100 + "%";
-//	}
-//
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//		if (!(tile instanceof TileFarmHatch)) {
-//			return false;
-//		}
-//
-//		TileFarmHatch tileHatch = (TileFarmHatch) tile;
-//		IInventory fertilizerInventory = tileHatch.getMultiblockLogic().getController().getFarmInventory().getFertilizerInventory();
-//		return InventoryUtil.containsPercent(fertilizerInventory, threshold);
-//	}
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.triggers.Trigger;
+import forestry.core.utils.InventoryUtil;
+import forestry.farming.tiles.TileFarmHatch;
+
+public class TriggerLowFertilizer extends Trigger {
+
+	private final float threshold;
+
+	public TriggerLowFertilizer(String tag, float threshold) {
+		super(tag, "lowFertilizer");
+		this.threshold = threshold;
+	}
+
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold * 100 + "%";
+	}
+
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+		if (!(tile instanceof TileFarmHatch)) {
+			return false;
+		}
+
+		TileFarmHatch tileHatch = (TileFarmHatch) tile;
+		IInventory fertilizerInventory = tileHatch.getMultiblockLogic().getController().getFarmInventory().getFertilizerInventory();
+		return InventoryUtil.containsPercent(fertilizerInventory, threshold);
+	}
 }

--- a/src/main/java/forestry/farming/triggers/TriggerLowGermlings.java
+++ b/src/main/java/forestry/farming/triggers/TriggerLowGermlings.java
@@ -10,34 +10,41 @@
  ******************************************************************************/
 package forestry.farming.triggers;
 
-import forestry.core.triggers.Trigger;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-// TODO: Buildcraft for 1.9
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.triggers.Trigger;
+import forestry.core.utils.InventoryUtil;
+import forestry.farming.tiles.TileFarmHatch;
+
 public class TriggerLowGermlings extends Trigger {
 
 	private final float threshold;
 
 	public TriggerLowGermlings(String tag, float threshold) {
-//		super(tag, "lowGermlings");
+		super(tag, "lowGermlings");
 		this.threshold = threshold;
 	}
 
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold * 100 + "%";
-//	}
-//
-//	/**
-//	 * Return true if the tile given in parameter activates the trigger, given the parameters.
-//	 */
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//		if (!(tile instanceof TileFarmHatch)) {
-//			return false;
-//		}
-//
-//		TileFarmHatch tileHatch = (TileFarmHatch) tile;
-//		IInventory germlingsInventory = tileHatch.getMultiblockLogic().getController().getFarmInventory().getGermlingsInventory();
-//		return InventoryUtil.containsPercent(germlingsInventory, threshold);
-//	}
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold * 100 + "%";
+	}
+
+	/**
+	 * Return true if the tile given in parameter activates the trigger, given the parameters.
+	 */
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+		if (!(tile instanceof TileFarmHatch)) {
+			return false;
+		}
+
+		TileFarmHatch tileHatch = (TileFarmHatch) tile;
+		IInventory germlingsInventory = tileHatch.getMultiblockLogic().getController().getFarmInventory().getGermlingsInventory();
+		return InventoryUtil.containsPercent(germlingsInventory, threshold);
+	}
 }

--- a/src/main/java/forestry/farming/triggers/TriggerLowGermlings.java
+++ b/src/main/java/forestry/farming/triggers/TriggerLowGermlings.java
@@ -25,7 +25,7 @@ public class TriggerLowGermlings extends Trigger {
 	private final float threshold;
 
 	public TriggerLowGermlings(String tag, float threshold) {
-		super(tag, "lowGermlings");
+		super(tag, "lowGermlings", "low_germlings");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/farming/triggers/TriggerLowLiquid.java
+++ b/src/main/java/forestry/farming/triggers/TriggerLowLiquid.java
@@ -25,7 +25,7 @@ public class TriggerLowLiquid extends Trigger {
 	private final float threshold;
 
 	public TriggerLowLiquid(String tag, float threshold) {
-		super(tag, "lowLiquid");
+		super(tag, "lowLiquid", "low_liquid");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/farming/triggers/TriggerLowLiquid.java
+++ b/src/main/java/forestry/farming/triggers/TriggerLowLiquid.java
@@ -10,40 +10,47 @@
  ******************************************************************************/
 package forestry.farming.triggers;
 
-import forestry.core.triggers.Trigger;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fluids.IFluidTank;
 
-// TODO: Buildcraft for 1.9
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.fluids.ITankManager;
+import forestry.core.triggers.Trigger;
+import forestry.farming.tiles.TileFarmHatch;
+
 public class TriggerLowLiquid extends Trigger {
 
 	private final float threshold;
 
 	public TriggerLowLiquid(String tag, float threshold) {
-//		super(tag, "lowLiquid");
+		super(tag, "lowLiquid");
 		this.threshold = threshold;
 	}
 
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold * 100 + "%";
-//	}
-//
-//	/**
-//	 * Return true if the tile given in parameter activates the trigger, given
-//	 * the parameters.
-//	 */
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//		if (!(tile instanceof TileFarmHatch)) {
-//			return false;
-//		}
-//
-//		TileFarmHatch tileHatch = (TileFarmHatch) tile;
-//		ITankManager tankManager = tileHatch.getMultiblockLogic().getController().getTankManager();
-//
-//		IFluidTank tank = tankManager.getTank(0);
-//		if (tank.getCapacity() == 0) {
-//			return false;
-//		}
-//		return (float) tank.getFluidAmount() / tank.getCapacity() <= threshold;
-//	}
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold * 100 + "%";
+	}
+
+	/**
+	 * Return true if the tile given in parameter activates the trigger, given
+	 * the parameters.
+	 */
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+		if (!(tile instanceof TileFarmHatch)) {
+			return false;
+		}
+
+		TileFarmHatch tileHatch = (TileFarmHatch) tile;
+		ITankManager tankManager = tileHatch.getMultiblockLogic().getController().getTankManager();
+
+		IFluidTank tank = tankManager.getTank(0);
+		if (tank.getCapacity() == 0) {
+			return false;
+		}
+		return (float) tank.getFluidAmount() / tank.getCapacity() <= threshold;
+	}
 }

--- a/src/main/java/forestry/farming/triggers/TriggerLowSoil.java
+++ b/src/main/java/forestry/farming/triggers/TriggerLowSoil.java
@@ -10,54 +10,65 @@
  ******************************************************************************/
 package forestry.farming.triggers;
 
-import forestry.core.triggers.Trigger;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.NonNullList;
 
-// TODO: Buildcraft for 1.9
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.api.farming.IFarmInventory;
+import forestry.api.multiblock.IFarmController;
+import forestry.core.triggers.Trigger;
+import forestry.core.utils.InventoryUtil;
+import forestry.farming.tiles.TileFarmHatch;
+
 public class TriggerLowSoil extends Trigger {
 
 	private final int threshold;
 
 	public TriggerLowSoil(int threshold) {
-//		super("lowSoil." + threshold, "lowSoil");
+		super("lowSoil." + threshold, "lowSoil");
 		this.threshold = threshold;
 	}
 
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold;
-//	}
-//
-//	@Override
-//	public int maxParameters() {
-//		return 1;
-//	}
-//
-//	/**
-//	 * Return true if the tile given in parameter activates the trigger, given
-//	 * the parameters.
-//	 */
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//		IStatementParameter parameter = null;
-//		if (parameters.length > 0) {
-//			parameter = parameters[0];
-//		}
-//
-//		if (!(tile instanceof TileFarmHatch)) {
-//			return false;
-//		}
-//
-//		TileFarmHatch tileHatch = (TileFarmHatch) tile;
-//		IFarmController farmController = tileHatch.getMultiblockLogic().getController();
-//		IFarmInventory farmInventory = farmController.getFarmInventory();
-//
-//		if (parameter == null || parameter.getItemStack() == null) {
-//			IInventory resourcesInventory = farmInventory.getResourcesInventory();
-//			return InventoryUtil.containsPercent(resourcesInventory, threshold);
-//		} else {
-//			ItemStack filter = parameter.getItemStack().copy();
-//			filter.setCount(threshold);
-//			return farmInventory.hasResources(new ItemStack[]{filter});
-//		}
-//	}
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold;
+	}
+
+	@Override
+	public int maxParameters() {
+		return 1;
+	}
+
+	/**
+	 * Return true if the tile given in parameter activates the trigger, given
+	 * the parameters.
+	 */
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+		IStatementParameter parameter = null;
+		if (parameters.length > 0) {
+			parameter = parameters[0];
+		}
+
+		if (!(tile instanceof TileFarmHatch)) {
+			return false;
+		}
+
+		TileFarmHatch tileHatch = (TileFarmHatch) tile;
+		IFarmController farmController = tileHatch.getMultiblockLogic().getController();
+		IFarmInventory farmInventory = farmController.getFarmInventory();
+
+		if (parameter == null || parameter.getItemStack().isEmpty()) {
+			IInventory resourcesInventory = farmInventory.getResourcesInventory();
+			return InventoryUtil.containsPercent(resourcesInventory, threshold);
+		} else {
+			ItemStack filter = parameter.getItemStack().copy();
+			filter.setCount(threshold);
+			return farmInventory.hasResources(NonNullList.from(ItemStack.EMPTY, filter));
+		}
+	}
 }

--- a/src/main/java/forestry/farming/triggers/TriggerLowSoil.java
+++ b/src/main/java/forestry/farming/triggers/TriggerLowSoil.java
@@ -29,7 +29,7 @@ public class TriggerLowSoil extends Trigger {
 	private final int threshold;
 
 	public TriggerLowSoil(int threshold) {
-		super("lowSoil." + threshold, "lowSoil");
+		super("lowSoil." + threshold, "lowSoil", "low_soil");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/greenhouse/gui/GreenhouseEnergyLedger.java
+++ b/src/main/java/forestry/greenhouse/gui/GreenhouseEnergyLedger.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.greenhouse.gui;
 
+import forestry.core.config.Config;
 import forestry.core.gui.ledgers.Ledger;
 import forestry.core.gui.ledgers.LedgerManager;
 import forestry.core.render.TextureManagerForestry;
@@ -41,7 +42,7 @@ public class GreenhouseEnergyLedger extends Ledger {
 		drawHeader(Translator.translateToLocal("for.gui.energy"), x + 22, y + 8);
 
 		drawSubheader(Translator.translateToLocal("for.gui.stored") + ':', x + 22, y + 20);
-		drawText(controller.getEnergyManager().getEnergyStored() + " RF", x + 22, y + 32);
+		drawText(Config.energyDisplayMode.formatEnergyValue(controller.getEnergyManager().getEnergyStored()), x + 22, y + 32);
 	}
 
 	@Override

--- a/src/main/java/forestry/mail/ModuleMail.java
+++ b/src/main/java/forestry/mail/ModuleMail.java
@@ -12,14 +12,13 @@ package forestry.mail;
 
 import com.google.common.base.Preconditions;
 
-import javax.annotation.Nullable;
-
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
+
+import javax.annotation.Nullable;
 
 import forestry.api.circuits.ICircuit;
 import forestry.api.mail.EnumAddressee;
@@ -45,6 +44,7 @@ import forestry.mail.commands.CommandMail;
 import forestry.mail.items.EnumStampDefinition;
 import forestry.mail.items.ItemRegistryMail;
 import forestry.mail.network.PacketRegistryMail;
+import forestry.mail.triggers.MailTriggers;
 import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
 import forestry.modules.ModuleHelper;
@@ -88,11 +88,10 @@ public class ModuleMail extends BlankForestryModule {
 		}
 	}
 
-	// TODO: Buildcraft for 1.9
-//	@Override
-//	public void registerTriggers() {
-//		MailTriggers.initialize();
-//	}
+	@Override
+	public void registerTriggers() {
+		MailTriggers.initialize();
+	}
 
 	@Override
 	public void doInit() {

--- a/src/main/java/forestry/mail/tiles/TileMailbox.java
+++ b/src/main/java/forestry/mail/tiles/TileMailbox.java
@@ -94,7 +94,7 @@ public class TileMailbox extends TileBase {
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		super.addExternalTriggers(triggers, side, tile);
-		triggers.add(MailTriggers.triggerHasMail);
+		// triggers.add(MailTriggers.triggerHasMail);
 	}
 
 	@Override

--- a/src/main/java/forestry/mail/tiles/TileMailbox.java
+++ b/src/main/java/forestry/mail/tiles/TileMailbox.java
@@ -10,11 +10,13 @@
  ******************************************************************************/
 package forestry.mail.tiles;
 
+import buildcraft.api.statements.ITriggerExternal;
 import com.mojang.authlib.GameProfile;
 import forestry.api.mail.ILetter;
 import forestry.api.mail.IMailAddress;
 import forestry.api.mail.IPostalState;
 import forestry.api.mail.PostManager;
+import forestry.core.config.Constants;
 import forestry.core.inventory.InventoryAdapter;
 import forestry.core.tiles.TileBase;
 import forestry.mail.EnumDeliveryState;
@@ -22,15 +24,22 @@ import forestry.mail.POBox;
 import forestry.mail.PostRegistry;
 import forestry.mail.gui.ContainerMailbox;
 import forestry.mail.gui.GuiMailbox;
+import forestry.mail.triggers.MailTriggers;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
 
 public class TileMailbox extends TileBase {
 
@@ -79,6 +88,13 @@ public class TileMailbox extends TileBase {
 		}
 
 		return result;
+	}
+
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		super.addExternalTriggers(triggers, side, tile);
+		triggers.add(MailTriggers.triggerHasMail);
 	}
 
 	@Override

--- a/src/main/java/forestry/mail/tiles/TileTrader.java
+++ b/src/main/java/forestry/mail/tiles/TileTrader.java
@@ -12,6 +12,7 @@ package forestry.mail.tiles;
 
 import com.google.common.base.Preconditions;
 
+import forestry.core.config.Constants;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -316,7 +317,7 @@ public class TileTrader extends TileBase implements IOwnedTile {
 		return (TradeStation) PostManager.postRegistry.getOrCreateTradeStation(world, getOwnerHandler().getOwner(), address);
 	}
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		super.addExternalTriggers(triggers, side, tile);

--- a/src/main/java/forestry/mail/tiles/TileTrader.java
+++ b/src/main/java/forestry/mail/tiles/TileTrader.java
@@ -10,9 +10,27 @@
  ******************************************************************************/
 package forestry.mail.tiles;
 
-import java.io.IOException;
-
 import com.google.common.base.Preconditions;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+
+import buildcraft.api.statements.ITriggerExternal;
 import forestry.api.core.IErrorLogic;
 import forestry.api.mail.IMailAddress;
 import forestry.api.mail.IStamps;
@@ -35,15 +53,7 @@ import forestry.mail.gui.GuiTradeName;
 import forestry.mail.gui.GuiTrader;
 import forestry.mail.inventory.InventoryTradeStation;
 import forestry.mail.network.packets.PacketTraderAddressResponse;
-import net.minecraft.client.gui.inventory.GuiContainer;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Items;
-import net.minecraft.inventory.Container;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
+import forestry.mail.triggers.MailTriggers;
 
 public class TileTrader extends TileBase implements IOwnedTile {
 	private final OwnerHandler ownerHandler = new OwnerHandler();
@@ -306,21 +316,19 @@ public class TileTrader extends TileBase implements IOwnedTile {
 		return (TradeStation) PostManager.postRegistry.getOrCreateTradeStation(world, getOwnerHandler().getOwner(), address);
 	}
 
-	// TODO: Buildcraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		LinkedList<ITriggerExternal> res = new LinkedList<>();
-//		res.add(MailTriggers.lowPaper64);
-//		res.add(MailTriggers.lowPaper32);
-//		res.add(MailTriggers.lowInput25);
-//		res.add(MailTriggers.lowInput10);
-//		res.add(MailTriggers.lowPostage40);
-//		res.add(MailTriggers.lowPostage20);
-//		res.add(MailTriggers.highBuffer90);
-//		res.add(MailTriggers.highBuffer75);
-//		return res;
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		super.addExternalTriggers(triggers, side, tile);
+		triggers.add(MailTriggers.lowPaper64);
+		triggers.add(MailTriggers.lowPaper32);
+		triggers.add(MailTriggers.lowInput25);
+		triggers.add(MailTriggers.lowInput10);
+		triggers.add(MailTriggers.lowPostage40);
+		triggers.add(MailTriggers.lowPostage20);
+		triggers.add(MailTriggers.highBuffer90);
+		triggers.add(MailTriggers.highBuffer75);
+	}
 
 	@Override
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/forestry/mail/triggers/MailTriggers.java
+++ b/src/main/java/forestry/mail/triggers/MailTriggers.java
@@ -10,27 +10,28 @@
  ******************************************************************************/
 package forestry.mail.triggers;
 
-// TODO: Buildcraft for 1.9
+import forestry.core.triggers.Trigger;
+
 public class MailTriggers {
-//	public static Trigger triggerHasMail;
-//	public static Trigger lowPaper64;
-//	public static Trigger lowPaper32;
-//	public static Trigger lowPostage40;
-//	public static Trigger lowPostage20;
-//	public static Trigger lowInput25;
-//	public static Trigger lowInput10;
-//	public static Trigger highBuffer75;
-//	public static Trigger highBuffer90;
-//
-//	public static void initialize() {
-//		triggerHasMail = new TriggerHasMail();
-//		lowPaper64 = new TriggerLowPaper("mail.lowPaper.64", 64);
-//		lowPaper32 = new TriggerLowPaper("mail.lowPaper.32", 32);
-//		lowPostage40 = new TriggerLowStamps("mail.lowStamps.40", 40);
-//		lowPostage20 = new TriggerLowStamps("mail.lowStamps.20", 20);
-//		lowInput25 = new TriggerLowInput("mail.lowInput.25", 0.25f);
-//		lowInput10 = new TriggerLowInput("mail.lowInput.10", 0.1f);
-//		highBuffer75 = new TriggerBuffer("mail.lowBuffer.75", 0.75f);
-//		highBuffer90 = new TriggerBuffer("mail.lowBuffer.90", 0.90f);
-//	}
+	public static Trigger triggerHasMail;
+	public static Trigger lowPaper64;
+	public static Trigger lowPaper32;
+	public static Trigger lowPostage40;
+	public static Trigger lowPostage20;
+	public static Trigger lowInput25;
+	public static Trigger lowInput10;
+	public static Trigger highBuffer75;
+	public static Trigger highBuffer90;
+
+	public static void initialize() {
+		triggerHasMail = new TriggerHasMail();
+		lowPaper64 = new TriggerLowPaper("mail.lowPaper.64", 64);
+		lowPaper32 = new TriggerLowPaper("mail.lowPaper.32", 32);
+		lowPostage40 = new TriggerLowStamps("mail.lowStamps.40", 40);
+		lowPostage20 = new TriggerLowStamps("mail.lowStamps.20", 20);
+		lowInput25 = new TriggerLowInput("mail.lowInput.25", 0.25f);
+		lowInput10 = new TriggerLowInput("mail.lowInput.10", 0.1f);
+		highBuffer75 = new TriggerBuffer("mail.lowBuffer.75", 0.75f);
+		highBuffer90 = new TriggerBuffer("mail.lowBuffer.90", 0.90f);
+	}
 }

--- a/src/main/java/forestry/mail/triggers/MailTriggers.java
+++ b/src/main/java/forestry/mail/triggers/MailTriggers.java
@@ -24,7 +24,7 @@ public class MailTriggers {
 	public static Trigger highBuffer90;
 
 	public static void initialize() {
-		triggerHasMail = new TriggerHasMail();
+		// triggerHasMail = new TriggerHasMail();
 		lowPaper64 = new TriggerLowPaper("mail.lowPaper.64", 64);
 		lowPaper32 = new TriggerLowPaper("mail.lowPaper.32", 32);
 		lowPostage40 = new TriggerLowStamps("mail.lowStamps.40", 40);

--- a/src/main/java/forestry/mail/triggers/TriggerBuffer.java
+++ b/src/main/java/forestry/mail/triggers/TriggerBuffer.java
@@ -23,7 +23,7 @@ public class TriggerBuffer extends Trigger {
 	private final float threshold;
 
 	public TriggerBuffer(String tag, float threshold) {
-		super(tag, "mailBuffer");
+		super(tag, "mailBuffer", "mail_buffer");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/mail/triggers/TriggerBuffer.java
+++ b/src/main/java/forestry/mail/triggers/TriggerBuffer.java
@@ -10,28 +10,35 @@
  ******************************************************************************/
 package forestry.mail.triggers;
 
-// TODO: Buildcraft for 1.9
-public class TriggerBuffer {//extends Trigger {
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-//	private final float threshold;
-//
-//	public TriggerBuffer(String tag, float threshold) {
-//		super(tag, "mailBuffer");
-//		this.threshold = threshold;
-//	}
-//
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " > " + threshold * 100 + "%";
-//	}
-//
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (!(tile instanceof TileTrader)) {
-//			return false;
-//		}
-//
-//		return ((TileTrader) tile).hasOutputBufMin(threshold);
-//	}
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.triggers.Trigger;
+import forestry.mail.tiles.TileTrader;
+
+public class TriggerBuffer extends Trigger {
+
+	private final float threshold;
+
+	public TriggerBuffer(String tag, float threshold) {
+		super(tag, "mailBuffer");
+		this.threshold = threshold;
+	}
+
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " > " + threshold * 100 + "%";
+	}
+
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+
+		if (!(tile instanceof TileTrader)) {
+			return false;
+		}
+
+		return ((TileTrader) tile).hasOutputBufMin(threshold);
+	}
 }

--- a/src/main/java/forestry/mail/triggers/TriggerHasMail.java
+++ b/src/main/java/forestry/mail/triggers/TriggerHasMail.java
@@ -33,7 +33,7 @@ public class TriggerHasMail extends Trigger {
 		// }
 		//
 		// return ((IMailContainer) tile).hasMail();
-		throw new NotImplementedException("not implemented");
+		return false;
 	}
 
 }

--- a/src/main/java/forestry/mail/triggers/TriggerHasMail.java
+++ b/src/main/java/forestry/mail/triggers/TriggerHasMail.java
@@ -10,14 +10,12 @@
  ******************************************************************************/
 package forestry.mail.triggers;
 
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-
-import org.apache.commons.lang3.NotImplementedException;
-
 import buildcraft.api.statements.IStatementContainer;
 import buildcraft.api.statements.IStatementParameter;
 import forestry.core.triggers.Trigger;
+import forestry.mail.tiles.TileMailbox;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
 public class TriggerHasMail extends Trigger {
 
@@ -27,13 +25,11 @@ public class TriggerHasMail extends Trigger {
 
 	@Override
 	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-		// TODO therealfarfetchd
-		// if (!(tile instanceof IMailContainer)) {
-		// 	return false;
-		// }
-		//
-		// return ((IMailContainer) tile).hasMail();
-		return false;
+		if (!(tile instanceof TileMailbox)) {
+			return false;
+		}
+
+		return !((TileMailbox) tile).getInternalInventory().isEmpty();
 	}
 
 }

--- a/src/main/java/forestry/mail/triggers/TriggerHasMail.java
+++ b/src/main/java/forestry/mail/triggers/TriggerHasMail.java
@@ -20,7 +20,7 @@ import net.minecraft.util.EnumFacing;
 public class TriggerHasMail extends Trigger {
 
 	public TriggerHasMail() {
-		super("mail.hasMail", "hasMail");
+		super("mail.hasMail", "hasMail", "has_mail");
 	}
 
 	@Override

--- a/src/main/java/forestry/mail/triggers/TriggerHasMail.java
+++ b/src/main/java/forestry/mail/triggers/TriggerHasMail.java
@@ -10,26 +10,26 @@
  ******************************************************************************/
 package forestry.mail.triggers;
 
-import buildcraft.api.statements.IStatementContainer;
-import buildcraft.api.statements.IStatementParameter;
-import forestry.core.triggers.Trigger;
-import forestry.mail.tiles.TileMailbox;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
-
-public class TriggerHasMail extends Trigger {
-
-	public TriggerHasMail() {
-		super("mail.hasMail", "hasMail", "has_mail");
-	}
-
-	@Override
-	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-		if (!(tile instanceof TileMailbox)) {
-			return false;
-		}
-
-		return !((TileMailbox) tile).getInternalInventory().isEmpty();
-	}
-
-}
+// import buildcraft.api.statements.IStatementContainer;
+// import buildcraft.api.statements.IStatementParameter;
+// import forestry.core.triggers.Trigger;
+// import forestry.mail.tiles.TileMailbox;
+// import net.minecraft.tileentity.TileEntity;
+// import net.minecraft.util.EnumFacing;
+//
+// public class TriggerHasMail extends Trigger {
+//
+// 	public TriggerHasMail() {
+// 		super("mail.hasMail", "hasMail", "has_mail");
+// 	}
+//
+// 	@Override
+// 	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+// 		if (!(tile instanceof TileMailbox)) {
+// 			return false;
+// 		}
+//
+// 		return !((TileMailbox) tile).getInternalInventory().isEmpty();
+// 	}
+//
+// }

--- a/src/main/java/forestry/mail/triggers/TriggerHasMail.java
+++ b/src/main/java/forestry/mail/triggers/TriggerHasMail.java
@@ -10,21 +10,30 @@
  ******************************************************************************/
 package forestry.mail.triggers;
 
-// TODO: Buildcraft for 1.9
-public class TriggerHasMail {//extends Trigger {
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-//	public TriggerHasMail() {
-//		super("mail.hasMail", "hasMail");
-//	}
-//
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (!(tile instanceof IMailContainer)) {
-//			return false;
-//		}
-//
-//		return ((IMailContainer) tile).hasMail();
-//	}
+import org.apache.commons.lang3.NotImplementedException;
+
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.triggers.Trigger;
+
+public class TriggerHasMail extends Trigger {
+
+	public TriggerHasMail() {
+		super("mail.hasMail", "hasMail");
+	}
+
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+		// TODO therealfarfetchd
+		// if (!(tile instanceof IMailContainer)) {
+		// 	return false;
+		// }
+		//
+		// return ((IMailContainer) tile).hasMail();
+		throw new NotImplementedException("not implemented");
+	}
 
 }

--- a/src/main/java/forestry/mail/triggers/TriggerLowInput.java
+++ b/src/main/java/forestry/mail/triggers/TriggerLowInput.java
@@ -10,28 +10,35 @@
  ******************************************************************************/
 package forestry.mail.triggers;
 
-// TODO: Buildcraft for 1.9
-public class TriggerLowInput {//extends Trigger {
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-//	private final float threshold;
-//
-//	public TriggerLowInput(String tag, float threshold) {
-//		super(tag, "lowInput");
-//		this.threshold = threshold;
-//	}
-//
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold * 100 + "%";
-//	}
-//
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (!(tile instanceof TileTrader)) {
-//			return false;
-//		}
-//
-//		return !((TileTrader) tile).hasInputBufMin(threshold);
-//	}
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.triggers.Trigger;
+import forestry.mail.tiles.TileTrader;
+
+public class TriggerLowInput extends Trigger {
+
+	private final float threshold;
+
+	public TriggerLowInput(String tag, float threshold) {
+		super(tag, "lowInput");
+		this.threshold = threshold;
+	}
+
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold * 100 + "%";
+	}
+
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+
+		if (!(tile instanceof TileTrader)) {
+			return false;
+		}
+
+		return !((TileTrader) tile).hasInputBufMin(threshold);
+	}
 }

--- a/src/main/java/forestry/mail/triggers/TriggerLowInput.java
+++ b/src/main/java/forestry/mail/triggers/TriggerLowInput.java
@@ -23,7 +23,7 @@ public class TriggerLowInput extends Trigger {
 	private final float threshold;
 
 	public TriggerLowInput(String tag, float threshold) {
-		super(tag, "lowInput");
+		super(tag, "lowInput", "low_input");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/mail/triggers/TriggerLowPaper.java
+++ b/src/main/java/forestry/mail/triggers/TriggerLowPaper.java
@@ -23,7 +23,7 @@ public class TriggerLowPaper extends Trigger {
 	private final int threshold;
 
 	public TriggerLowPaper(String tag, int threshold) {
-		super(tag, "lowPaper");
+		super(tag, "lowPaper", "low_paper");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/mail/triggers/TriggerLowPaper.java
+++ b/src/main/java/forestry/mail/triggers/TriggerLowPaper.java
@@ -10,29 +10,36 @@
  ******************************************************************************/
 package forestry.mail.triggers;
 
-// TODO: Buildcraft for 1.9
-public class TriggerLowPaper {//} extends Trigger {
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 
-//	private final int threshold;
-//
-//	public TriggerLowPaper(String tag, int threshold) {
-//		super(tag, "lowPaper");
-//		this.threshold = threshold;
-//	}
-//
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold;
-//	}
-//
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (!(tile instanceof TileTrader)) {
-//			return false;
-//		}
-//
-//		return !((TileTrader) tile).hasPaperMin(threshold);
-//	}
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.triggers.Trigger;
+import forestry.mail.tiles.TileTrader;
+
+public class TriggerLowPaper extends Trigger {
+
+	private final int threshold;
+
+	public TriggerLowPaper(String tag, int threshold) {
+		super(tag, "lowPaper");
+		this.threshold = threshold;
+	}
+
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold;
+	}
+
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+
+		if (!(tile instanceof TileTrader)) {
+			return false;
+		}
+
+		return !((TileTrader) tile).hasPaperMin(threshold);
+	}
 
 }

--- a/src/main/java/forestry/mail/triggers/TriggerLowStamps.java
+++ b/src/main/java/forestry/mail/triggers/TriggerLowStamps.java
@@ -10,29 +10,36 @@
  ******************************************************************************/
 package forestry.mail.triggers;
 
-// TODO: Buildcraft for 1.9
-public class TriggerLowStamps {//extends Trigger {
-//
-//	private final int threshold;
-//
-//	public TriggerLowStamps(String tag, int threshold) {
-//		super(tag, "lowStamps");
-//		this.threshold = threshold;
-//	}
-//
-//	@Override
-//	public String getDescription() {
-//		return super.getDescription() + " < " + threshold + "p";
-//	}
-//
-//	@Override
-//	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
-//
-//		if (!(tile instanceof TileTrader)) {
-//			return false;
-//		}
-//
-//		return !((TileTrader) tile).hasPostageMin(threshold);
-//	}
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import forestry.core.triggers.Trigger;
+import forestry.mail.tiles.TileTrader;
+
+public class TriggerLowStamps extends Trigger {
+
+	private final int threshold;
+
+	public TriggerLowStamps(String tag, int threshold) {
+		super(tag, "lowStamps");
+		this.threshold = threshold;
+	}
+
+	@Override
+	public String getDescription() {
+		return super.getDescription() + " < " + threshold + "p";
+	}
+
+	@Override
+	public boolean isTriggerActive(TileEntity tile, EnumFacing side, IStatementContainer source, IStatementParameter[] parameters) {
+
+		if (!(tile instanceof TileTrader)) {
+			return false;
+		}
+
+		return !((TileTrader) tile).hasPostageMin(threshold);
+	}
 
 }

--- a/src/main/java/forestry/mail/triggers/TriggerLowStamps.java
+++ b/src/main/java/forestry/mail/triggers/TriggerLowStamps.java
@@ -23,7 +23,7 @@ public class TriggerLowStamps extends Trigger {
 	private final int threshold;
 
 	public TriggerLowStamps(String tag, int threshold) {
-		super(tag, "lowStamps");
+		super(tag, "lowStamps", "low_stamps");
 		this.threshold = threshold;
 	}
 

--- a/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
@@ -10,13 +10,22 @@
  ******************************************************************************/
 package forestry.plugins;
 
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.common.Optional;
+
+import buildcraft.api.fuels.BuildcraftFuelRegistry;
+import buildcraft.api.fuels.ICoolant;
+import buildcraft.api.fuels.ICoolantManager;
+import forestry.api.core.ForestryAPI;
 import forestry.api.modules.ForestryModule;
 import forestry.core.config.Constants;
+import forestry.core.fluids.Fluids;
 import forestry.core.utils.ModUtil;
 import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
 
-// TODO: Buildcraft for 1.9
 @ForestryModule(containerID = ForestryCompatPlugins.ID, moduleID = ForestryModuleUids.BUILDCRAFT_FUELS, name = "BuildCraft 6 Fuels", author = "mezz", url = Constants.URL, unlocalizedDescription = "for.module.buildcraft6.description")
 public class PluginBuildCraftFuels extends BlankForestryModule {
 
@@ -30,21 +39,22 @@ public class PluginBuildCraftFuels extends BlankForestryModule {
 		return "Compatible BuildCraftAPI|fuels version not found";
 	}
 
-//	@Optional.Method(modid = "BuildCraftAPI|fuels")
-//	@Override
-//	public void doInit() {
-//		ICoolantManager coolantManager = BuildcraftFuelRegistry.coolant;
-	//		ICoolant waterCoolant = coolantManager.getCoolant(FluidRegistry.WATER);
-//		float waterCooling = waterCoolant.getDegreesCoolingPerMB(100);
-//
-//		coolantManager.addCoolant(Fluids.ICE.getFluid(), Constants.ICE_COOLING_MULTIPLIER * waterCooling);
-//
-//		Fluid ethanol = Fluids.BIO_ETHANOL.getFluid();
-//		if (ethanol != null) {
-//			int ethanolPower = 40;
-//			int ethanolBurnTime = Math.round(Constants.ENGINE_CYCLE_DURATION_ETHANOL * ForestryAPI.activeMode.getFloatSetting("fuel.ethanol.combustion"));
-//			BuildcraftFuelRegistry.fuel.addFuel(ethanol, ethanolPower, ethanolBurnTime);
-//		}
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|fuels")
+	@Override
+	public void doInit() {
+		ICoolantManager coolantManager = BuildcraftFuelRegistry.coolant;
+		FluidStack water = new FluidStack(FluidRegistry.WATER, 1);
+		ICoolant waterCoolant = coolantManager.getCoolant(water);
+		float waterCooling = waterCoolant.getDegreesCoolingPerMB(water, 100);
+
+		coolantManager.addCoolant(Fluids.ICE.getFluid(), Constants.ICE_COOLING_MULTIPLIER * waterCooling);
+
+		Fluid ethanol = Fluids.BIO_ETHANOL.getFluid();
+		if (ethanol != null) {
+			int ethanolPower = 40;
+			int ethanolBurnTime = Math.round(Constants.ENGINE_CYCLE_DURATION_ETHANOL * ForestryAPI.activeMode.getFloatSetting("fuel.ethanol.combustion"));
+			BuildcraftFuelRegistry.fuel.addFuel(ethanol, ethanolPower, ethanolBurnTime);
+		}
+	}
 
 }

--- a/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
@@ -39,7 +39,7 @@ public class PluginBuildCraftFuels extends BlankForestryModule {
 		return "Compatible BuildCraftAPI|fuels version not found";
 	}
 
-	@Optional.Method(modid = "BuildCraftAPI|fuels")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void doInit() {
 		ICoolantManager coolantManager = BuildcraftFuelRegistry.coolant;

--- a/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
@@ -10,15 +10,10 @@
  ******************************************************************************/
 package forestry.plugins;
 
-import buildcraft.api.mj.MjAPI;
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fml.common.Optional;
-
 import buildcraft.api.fuels.BuildcraftFuelRegistry;
 import buildcraft.api.fuels.ICoolant;
 import buildcraft.api.fuels.ICoolantManager;
+import buildcraft.api.mj.MjAPI;
 import forestry.api.core.ForestryAPI;
 import forestry.api.modules.ForestryModule;
 import forestry.core.config.Constants;
@@ -26,13 +21,18 @@ import forestry.core.fluids.Fluids;
 import forestry.core.utils.ModUtil;
 import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fluids.FluidStack;
 
 @ForestryModule(containerID = ForestryCompatPlugins.ID, moduleID = ForestryModuleUids.BUILDCRAFT_FUELS, name = "BuildCraft 6 Fuels", author = "mezz", url = Constants.URL, unlocalizedDescription = "for.module.buildcraft6.description")
 public class PluginBuildCraftFuels extends BlankForestryModule {
 
+	public static final String MOD_ID = "buildcraftenergy";
+
 	@Override
 	public boolean isAvailable() {
-		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID);
+		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID, "[7.99.17,8.0)");
 	}
 
 	@Override
@@ -40,9 +40,8 @@ public class PluginBuildCraftFuels extends BlankForestryModule {
 		return "Compatible BuildCraftAPI|fuels version not found";
 	}
 
-	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
-	public void postInit() {
+	public void doInit() {
 		ICoolantManager coolantManager = BuildcraftFuelRegistry.coolant;
 		FluidStack water = new FluidStack(FluidRegistry.WATER, 1);
 		ICoolant waterCoolant = coolantManager.getCoolant(water);
@@ -56,11 +55,6 @@ public class PluginBuildCraftFuels extends BlankForestryModule {
 			int ethanolBurnTime = Math.round(Constants.ENGINE_CYCLE_DURATION_ETHANOL * ForestryAPI.activeMode.getFloatSetting("fuel.ethanol.combustion"));
 			BuildcraftFuelRegistry.fuel.addFuel(ethanol, ethanolPower, ethanolBurnTime);
 		}
-	}
-
-	@Override
-	public void doInit() {
-		// FIXME postInit belongs in here, really
 	}
 
 }

--- a/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
@@ -31,7 +31,7 @@ public class PluginBuildCraftFuels extends BlankForestryModule {
 
 	@Override
 	public boolean isAvailable() {
-		return ModUtil.isAPILoaded("buildcraft.api.fuels", "[2.0, 3.0)");
+		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID);
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class PluginBuildCraftFuels extends BlankForestryModule {
 
 	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
-	public void doInit() {
+	public void postInit() {
 		ICoolantManager coolantManager = BuildcraftFuelRegistry.coolant;
 		FluidStack water = new FluidStack(FluidRegistry.WATER, 1);
 		ICoolant waterCoolant = coolantManager.getCoolant(water);
@@ -55,6 +55,11 @@ public class PluginBuildCraftFuels extends BlankForestryModule {
 			int ethanolBurnTime = Math.round(Constants.ENGINE_CYCLE_DURATION_ETHANOL * ForestryAPI.activeMode.getFloatSetting("fuel.ethanol.combustion"));
 			BuildcraftFuelRegistry.fuel.addFuel(ethanol, ethanolPower, ethanolBurnTime);
 		}
+	}
+
+	@Override
+	public void doInit() {
+		// FIXME postInit belongs in here, really
 	}
 
 }

--- a/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftFuels.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.plugins;
 
+import buildcraft.api.mj.MjAPI;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
@@ -51,7 +52,7 @@ public class PluginBuildCraftFuels extends BlankForestryModule {
 
 		Fluid ethanol = Fluids.BIO_ETHANOL.getFluid();
 		if (ethanol != null) {
-			int ethanolPower = 40;
+			long ethanolPower = 40 * MjAPI.MJ;
 			int ethanolBurnTime = Math.round(Constants.ENGINE_CYCLE_DURATION_ETHANOL * ForestryAPI.activeMode.getFloatSetting("fuel.ethanol.combustion"));
 			BuildcraftFuelRegistry.fuel.addFuel(ethanol, ethanolPower, ethanolBurnTime);
 		}

--- a/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
@@ -24,7 +24,7 @@ public class PluginBuildCraftRecipes extends BlankForestryModule {
 
 	@Override
 	public boolean isAvailable() {
-		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID);
+		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID, "[7.99.17,8.0)");
 	}
 
 	@Override

--- a/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
@@ -12,8 +12,10 @@ package forestry.plugins;
 
 import net.minecraftforge.fml.common.Optional;
 
+import buildcraft.api.recipes.BuildcraftRecipeRegistry;
 import forestry.api.modules.ForestryModule;
 import forestry.core.config.Constants;
+import forestry.core.fluids.Fluids;
 import forestry.core.utils.ModUtil;
 import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
@@ -36,7 +38,8 @@ public class PluginBuildCraftRecipes extends BlankForestryModule {
 	@Override
 	public void registerRecipes() {
 		// Add recipe for ethanol
-		// TODO: Buildcraft for 1.9
-//		BuildcraftRecipeRegistry.refinery.addRecipe("forestry:BiomassToEthanol", Fluids.BIOMASS.getFluid(4), Fluids.BIO_ETHANOL.getFluid(1), 100, 1);
+		// TODO therealfarfetchd
+		// BuildcraftRecipeRegistry.refinery.addRecipe("forestry:BiomassToEthanol", Fluids.BIOMASS.getFluid(4), Fluids.BIO_ETHANOL.getFluid(1), 100, 1);
+		BuildcraftRecipeRegistry.refineryRecipes.addDistillationRecipe(Fluids.BIOMASS.getFluid(4), null, Fluids.BIO_ETHANOL.getFluid(1), 100);
 	}
 }

--- a/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
@@ -34,7 +34,7 @@ public class PluginBuildCraftRecipes extends BlankForestryModule {
 		return "Compatible BuildCraftAPI|recipes version not found";
 	}
 
-	@Optional.Method(modid = "BuildCraftAPI|recipes")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void registerRecipes() {
 		// Add recipe for ethanol

--- a/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
@@ -26,7 +26,7 @@ public class PluginBuildCraftRecipes extends BlankForestryModule {
 
 	@Override
 	public boolean isAvailable() {
-		return ModUtil.isAPILoaded("buildcraft.api.recipes", "[2.0, 4.0)");
+		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID);
 	}
 
 	@Override

--- a/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
@@ -10,8 +10,6 @@
  ******************************************************************************/
 package forestry.plugins;
 
-import net.minecraftforge.fml.common.Optional;
-
 import buildcraft.api.recipes.BuildcraftRecipeRegistry;
 import forestry.api.modules.ForestryModule;
 import forestry.core.config.Constants;
@@ -19,6 +17,7 @@ import forestry.core.fluids.Fluids;
 import forestry.core.utils.ModUtil;
 import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
+import net.minecraftforge.fml.common.Optional;
 
 
 @ForestryModule(containerID = ForestryCompatPlugins.ID, moduleID = ForestryModuleUids.BUILDCRAFT_RECIPES, name = "BuildCraft 6 Recipes", author = "SirSengir", url = Constants.URL, unlocalizedDescription = "for.module.buildcraft6.description")
@@ -40,6 +39,6 @@ public class PluginBuildCraftRecipes extends BlankForestryModule {
 		// Add recipe for ethanol
 		// TODO therealfarfetchd
 		// BuildcraftRecipeRegistry.refinery.addRecipe("forestry:BiomassToEthanol", Fluids.BIOMASS.getFluid(4), Fluids.BIO_ETHANOL.getFluid(1), 100, 1);
-		BuildcraftRecipeRegistry.refineryRecipes.addDistillationRecipe(Fluids.BIOMASS.getFluid(4), null, Fluids.BIO_ETHANOL.getFluid(1), 100);
+		BuildcraftRecipeRegistry.refineryRecipes.addDistillationRecipe(Fluids.BIOMASS.getFluid(4), Fluids.BIO_ETHANOL.getFluid(0), Fluids.BIO_ETHANOL.getFluid(1), 100);
 	}
 }

--- a/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.plugins;
 
+import buildcraft.api.mj.MjAPI;
 import buildcraft.api.recipes.BuildcraftRecipeRegistry;
 import forestry.api.modules.ForestryModule;
 import forestry.core.config.Constants;
@@ -36,7 +37,7 @@ public class PluginBuildCraftRecipes extends BlankForestryModule {
 	@Override
 	public void registerRecipes() {
 		// Add recipe for ethanol
-		BuildcraftRecipeRegistry.refineryRecipes.addDistillationRecipe(Fluids.BIOMASS.getFluid(4),
-				Fluids.BIO_ETHANOL.getFluid(0), Fluids.BIO_ETHANOL.getFluid(1), 100);
+		BuildcraftRecipeRegistry.refineryRecipes.addDistillationRecipe(Fluids.BIOMASS.getFluid(10),
+				Fluids.BIO_ETHANOL.getFluid(0), Fluids.BIO_ETHANOL.getFluid(3), 20 * MjAPI.MJ);
 	}
 }

--- a/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftRecipes.java
@@ -19,7 +19,6 @@ import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
 import net.minecraftforge.fml.common.Optional;
 
-
 @ForestryModule(containerID = ForestryCompatPlugins.ID, moduleID = ForestryModuleUids.BUILDCRAFT_RECIPES, name = "BuildCraft 6 Recipes", author = "SirSengir", url = Constants.URL, unlocalizedDescription = "for.module.buildcraft6.description")
 public class PluginBuildCraftRecipes extends BlankForestryModule {
 
@@ -37,8 +36,7 @@ public class PluginBuildCraftRecipes extends BlankForestryModule {
 	@Override
 	public void registerRecipes() {
 		// Add recipe for ethanol
-		// TODO therealfarfetchd
-		// BuildcraftRecipeRegistry.refinery.addRecipe("forestry:BiomassToEthanol", Fluids.BIOMASS.getFluid(4), Fluids.BIO_ETHANOL.getFluid(1), 100, 1);
-		BuildcraftRecipeRegistry.refineryRecipes.addDistillationRecipe(Fluids.BIOMASS.getFluid(4), Fluids.BIO_ETHANOL.getFluid(0), Fluids.BIO_ETHANOL.getFluid(1), 100);
+		BuildcraftRecipeRegistry.refineryRecipes.addDistillationRecipe(Fluids.BIOMASS.getFluid(4),
+				Fluids.BIO_ETHANOL.getFluid(0), Fluids.BIO_ETHANOL.getFluid(1), 100);
 	}
 }

--- a/src/main/java/forestry/plugins/PluginBuildCraftStatements.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftStatements.java
@@ -36,7 +36,7 @@ public class PluginBuildCraftStatements extends BlankForestryModule implements I
 
 	@Override
 	public boolean isAvailable() {
-		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID);
+		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID, "[7.99.17,8.0)");
 	}
 
 	@Override

--- a/src/main/java/forestry/plugins/PluginBuildCraftStatements.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftStatements.java
@@ -36,7 +36,7 @@ public class PluginBuildCraftStatements extends BlankForestryModule implements I
 
 	@Override
 	public boolean isAvailable() {
-		return ModUtil.isAPILoaded("buildcraft.api.statements", "[1.0, 2.0)");
+		return ModUtil.isModLoaded(Constants.BCLIB_MOD_ID);
 	}
 
 	@Override

--- a/src/main/java/forestry/plugins/PluginBuildCraftStatements.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftStatements.java
@@ -10,8 +10,20 @@
  ******************************************************************************/
 package forestry.plugins;
 
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.common.Optional;
 
+import java.util.Collection;
+
+import javax.annotation.Nonnull;
+
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.ITriggerExternal;
+import buildcraft.api.statements.ITriggerInternal;
+import buildcraft.api.statements.ITriggerInternalSided;
+import buildcraft.api.statements.ITriggerProvider;
+import buildcraft.api.statements.StatementManager;
 import forestry.api.modules.ForestryModule;
 import forestry.core.config.Constants;
 import forestry.core.utils.ModUtil;
@@ -19,8 +31,8 @@ import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
 
 @ForestryModule(containerID = ForestryCompatPlugins.ID, moduleID = ForestryModuleUids.BUILDCRAFT_STATEMENTS, name = "BuildCraft 6 Statements", author = "mezz", url = Constants.URL, unlocalizedDescription = "for.module.buildcraft6.description")
-//@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
-public class PluginBuildCraftStatements extends BlankForestryModule {//implements ITriggerProvider {
+@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
+public class PluginBuildCraftStatements extends BlankForestryModule implements ITriggerProvider {
 
 	@Override
 	public boolean isAvailable() {
@@ -36,31 +48,34 @@ public class PluginBuildCraftStatements extends BlankForestryModule {//implement
 	@Override
 	public void doInit() {
 		// Add custom trigger handler
-		// TODO: Buildcraft for 1.9
-//		StatementManager.registerTriggerProvider(this);
+		StatementManager.registerTriggerProvider(this);
 	}
 
 	/* ITriggerProvider */
 
-	// TODO: Buildcraft for 1.9
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerInternal> getInternalTriggers(IStatementContainer container) {
-//		TileEntity tile = container.getTile();
-//		if (tile instanceof ITriggerProvider) {
-//			return ((ITriggerProvider) tile).getInternalTriggers(container);
-//		}
-//
-//		return null;
-//	}
-//
-//	@Optional.Method(modid = "BuildCraftAPI|statements")
-//	@Override
-//	public Collection<ITriggerExternal> getExternalTriggers(EnumFacing side, TileEntity tile) {
-//		if (tile instanceof ITriggerProvider) {
-//			return ((ITriggerProvider) tile).getExternalTriggers(side, tile);
-//		}
-//
-//		return null;
-//	}
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addInternalTriggers(Collection<ITriggerInternal> triggers, IStatementContainer container) {
+		TileEntity tile = container.getTile();
+		if (tile instanceof ITriggerProvider) {
+			((ITriggerProvider) tile).addInternalTriggers(triggers, container);
+		}
+	}
+
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addInternalSidedTriggers(Collection<ITriggerInternalSided> triggers, IStatementContainer container, @Nonnull EnumFacing side) {
+		TileEntity tile = container.getTile();
+		if (tile instanceof ITriggerProvider) {
+			((ITriggerProvider) tile).addInternalSidedTriggers(triggers, container, side);
+		}
+	}
+
+	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Override
+	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
+		if (tile instanceof ITriggerProvider) {
+			((ITriggerProvider) tile).addExternalTriggers(triggers, side, tile);
+		}
+	}
 }

--- a/src/main/java/forestry/plugins/PluginBuildCraftStatements.java
+++ b/src/main/java/forestry/plugins/PluginBuildCraftStatements.java
@@ -31,7 +31,7 @@ import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
 
 @ForestryModule(containerID = ForestryCompatPlugins.ID, moduleID = ForestryModuleUids.BUILDCRAFT_STATEMENTS, name = "BuildCraft 6 Statements", author = "mezz", url = Constants.URL, unlocalizedDescription = "for.module.buildcraft6.description")
-@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = "BuildCraftAPI|statements")
+@Optional.Interface(iface = "buildcraft.api.statements.ITriggerProvider", modid = Constants.BCLIB_MOD_ID)
 public class PluginBuildCraftStatements extends BlankForestryModule implements ITriggerProvider {
 
 	@Override
@@ -44,7 +44,7 @@ public class PluginBuildCraftStatements extends BlankForestryModule implements I
 		return "Compatible BuildCraftAPI|statements version not found";
 	}
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void doInit() {
 		// Add custom trigger handler
@@ -53,7 +53,7 @@ public class PluginBuildCraftStatements extends BlankForestryModule implements I
 
 	/* ITriggerProvider */
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addInternalTriggers(Collection<ITriggerInternal> triggers, IStatementContainer container) {
 		TileEntity tile = container.getTile();
@@ -62,7 +62,7 @@ public class PluginBuildCraftStatements extends BlankForestryModule implements I
 		}
 	}
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addInternalSidedTriggers(Collection<ITriggerInternalSided> triggers, IStatementContainer container, @Nonnull EnumFacing side) {
 		TileEntity tile = container.getTile();
@@ -71,7 +71,7 @@ public class PluginBuildCraftStatements extends BlankForestryModule implements I
 		}
 	}
 
-	@Optional.Method(modid = "BuildCraftAPI|statements")
+	@Optional.Method(modid = Constants.BCLIB_MOD_ID)
 	@Override
 	public void addExternalTriggers(Collection<ITriggerExternal> triggers, @Nonnull EnumFacing side, TileEntity tile) {
 		if (tile instanceof ITriggerProvider) {

--- a/src/main/resources/assets/forestry/lang/en_us.lang
+++ b/src/main/resources/assets/forestry/lang/en_us.lang
@@ -1904,6 +1904,15 @@ for.config.gamemode.squeezer.mulch.apple.comment=modifies the chance of mulch pe
 
 for.config.gamemode.energy.engine.clockwork.comment=Enable the clockwork engine.
 
+for.config.power.types.rf=Redstone Flux
+for.config.power.types.rf.comment=Enable Redstone Flux power support.
+for.config.power.types.mj=MJ
+for.config.power.types.mj.comment=Enable MJ power support.
+for.config.power.types.tesla=Tesla
+for.config.power.types.tesla.comment=Enable Tesla power support.
+for.config.power.display.mode=Power Display Mode
+for.config.power.display.mode.comment=The format power will be displayed in in engine/machine interfaces.
+
 ###################################
 # CUSTOM BEE AND TREE SPECIES NAMES
 ###################################


### PR DESCRIPTION
Reimplements BuildCraft support. 

This includes:
 - Gate conditions
 - MJ support
 - Configuration options (power display in GUIs & toggle which power types can be used)
 - Misc stuff
 - It doesn't crash without BC

Misc stuff that doesn't work 100% (yet):
 - Has Mail trigger (doesn't work at all, no idea how to implement)
 - Engines don't output power in pulses like BC's but at a constant rate
 - Wrench doesn't work on BC machines

Compiles against BC 7.99.17, for now.