### PR TITLE
fix log not formatting correctly

### DIFF
--- a/src/main/java/forestry/apiculture/genetics/BeeRoot.java
+++ b/src/main/java/forestry/apiculture/genetics/BeeRoot.java
@@ -349,7 +349,7 @@ public class BeeRoot extends SpeciesRoot implements IBeeRoot {
 			}
 		}
 
-		Log.debug("Failed to find a beekeeping mode called '%s', reverting to fallback.");
+		Log.debug("Failed to find a beekeeping mode called '{}', reverting to fallback.", name);
 		return beekeepingModes.get(0);
 	}
 

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -370,7 +370,7 @@ public class Config {
 
 		disabledStructures.addAll(Arrays.asList(disabledStructureArray));
 		for (String str : disabledStructures) {
-			Log.debug("Disabled structure '%s'.", str);
+			Log.debug("Disabled structure '{}'.", str);
 		}
 
 		isDebug = configCommon.getBooleanLocalized("debug", "enabled", isDebug);

--- a/src/main/java/forestry/core/multiblock/MultiblockRegistry.java
+++ b/src/main/java/forestry/core/multiblock/MultiblockRegistry.java
@@ -108,7 +108,7 @@ public class MultiblockRegistry {
 		if (registries.containsKey(world)) {
 			registries.get(world).addDeadController(controller);
 		} else {
-			Log.warning("Controller %d in world %s marked as dead, but that world is not tracked! Controller is being ignored.", controller.hashCode(), world);
+			Log.warning("Controller {} in world {} marked as dead, but that world is not tracked! Controller is being ignored.", controller.hashCode(), world);
 		}
 	}
 

--- a/src/main/java/forestry/core/utils/EntityUtil.java
+++ b/src/main/java/forestry/core/utils/EntityUtil.java
@@ -44,7 +44,7 @@ public abstract class EntityUtil {
 
 	public static void registerEntity(ResourceLocation registryName, Class<? extends Entity> entityClass, String ident, int id, int eggForeground, int eggBackground, int trackingRange, int updateFrequency, boolean sendVelocity) {
 		EntityRegistry.registerModEntity(registryName, entityClass, ident, id, ForestryAPI.instance, trackingRange, updateFrequency, sendVelocity);
-		Log.debug("Registered entity %s (%s) with id %s.", ident, entityClass.toString(), id);
+		Log.debug("Registered entity {} ({}) with id {}.", ident, entityClass.toString(), id);
 	}
 
 	@Nullable

--- a/src/main/java/forestry/lepidopterology/ButterflyUtils.java
+++ b/src/main/java/forestry/lepidopterology/ButterflyUtils.java
@@ -13,7 +13,7 @@ public class ButterflyUtils {
 	
 	static boolean attemptButterflySpawn(World world, IButterfly butterfly, BlockPos pos) {
 		EntityLiving entityLiving = ButterflyManager.butterflyRoot.spawnButterflyInWorld(world, butterfly.copy(), pos.getX(), pos.getY() + 0.1f, pos.getZ());
-		Log.trace("Spawned a butterfly '%s' at %s/%s/%s.", butterfly.getDisplayName(), pos.getX(), pos.getY(), pos.getZ());
+		Log.trace("Spawned a butterfly '{}' at {}/{}/{}.", butterfly.getDisplayName(), pos.getX(), pos.getY(), pos.getZ());
 		return entityLiving != null;
 	}
 	


### PR DESCRIPTION
Closes #2023 
Closes #1947 
Closes #2035 

Docs [here](https://logging.apache.org/log4j/2.0/log4j-api/apidocs/org/apache/logging/log4j/Logger.html) suggest that `{}` is used instead of `%s` etc.