### PR TITLE
fix buildcraft dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,7 @@ dependencies {
 	runtime "mezz.jei:jei_${jei_mcversion}:${jei_version}"
 	deobfCompile "net.industrial-craft:industrialcraft-2:${ic2_version}:api"
 	deobfCompile "TechReborn:TechReborn-${TR_mcversion}:${TR_version}:api"
-	deobfProvided "com.mod-buildcraft:buildcraft-api:${buildcraft_version}"
-	runtimeOnly "com.mod-buildcraft:buildcraft:${buildcraft_version}"
+	deobfCompile "com.mod-buildcraft:buildcraft-api:${buildcraft_version}"
 }
 
 configurations {


### PR DESCRIPTION
- Buildcraft API is needed for compilation in dev
- Buildcraft is not necessary to launch the game so I don't think it should be automatically loaded.