### PR TITLE
fix cocoon tile name

### DIFF
--- a/src/main/java/forestry/core/utils/MigrationHelper.java
+++ b/src/main/java/forestry/core/utils/MigrationHelper.java
@@ -92,6 +92,8 @@ public class MigrationHelper {
 		addTileRemappingName("GreenhouseHeater", "greenhouse_heater");
 		addTileRemappingName("GreenhouseDryer", "greenhouse_dehumidifier");
 		addTileRemappingName("GreenhouseSprinkler", "greenhouse_humidifier");
+		//Lepidopterology
+		addTileRemappingName("Cocoon", "cocoon");
 		//Sorting
 		addTileRemappingName("GeneticFilter", "genetic_filter");
 

--- a/src/main/java/forestry/lepidopterology/ModuleLepidopterology.java
+++ b/src/main/java/forestry/lepidopterology/ModuleLepidopterology.java
@@ -57,6 +57,7 @@ import forestry.core.ModuleCore;
 import forestry.core.config.Constants;
 import forestry.core.config.LocalizedConfiguration;
 import forestry.core.recipes.RecipeUtil;
+import forestry.core.tiles.TileUtil;
 import forestry.core.utils.EntityUtil;
 import forestry.core.utils.ItemStackUtil;
 import forestry.core.utils.Log;
@@ -159,7 +160,7 @@ public class ModuleLepidopterology extends BlankForestryModule {
 	public void doInit() {
 		BlockRegistryLepidopterology blocks = getBlocks();
 
-		GameRegistry.registerTileEntity(TileCocoon.class, "forestry.Cocoon");
+		TileUtil.registerTile(TileCocoon.class, "cocoon");
 
 		ModuleCore.rootCommand.addChildCommand(new CommandButterfly());
 

--- a/src/main/java/forestry/lepidopterology/ModuleLepidopterology.java
+++ b/src/main/java/forestry/lepidopterology/ModuleLepidopterology.java
@@ -40,7 +40,6 @@ import net.minecraftforge.oredict.RecipeSorter;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -135,14 +134,14 @@ public class ModuleLepidopterology extends BlankForestryModule {
 		MinecraftForge.EVENT_BUS.register(this);
 		ButterflyBranchDefinition.createAlleles();
 		ButterflyAlleles.registerEffectAlleles();
-		
+
 		ButterflyDefinition.preInit();
 		MothDefinition.preInit();
 		MinecraftForge.EVENT_BUS.post(new AlleleSpeciesRegisterEvent<>(ButterflyManager.butterflyRoot, IAlleleButterflySpecies.class));
 
 		proxy.preInitializeRendering();
 
-		if(ModuleHelper.isEnabled(ForestryModuleUids.SORTING)){
+		if (ModuleHelper.isEnabled(ForestryModuleUids.SORTING)) {
 			LepidopterologyFilterRule.init();
 			LepidopterologyFilterRuleType.init();
 		}


### PR DESCRIPTION
This follows the same pattern as https://github.com/ForestryMC/ForestryMC/commit/9b4a4c2b1d0b495f180a4dfea2bcfe492546b4d0 and just finishes cleaning up tile registration names. If someone could let me know how to get the cocoon to test this it would be appreciated :smile: .