### PR TITLE
use getInternalInventory() instead of using the inventory field directly

### DIFF
--- a/src/main/java/forestry/core/tiles/TileForestry.java
+++ b/src/main/java/forestry/core/tiles/TileForestry.java
@@ -349,10 +349,10 @@ public abstract class TileForestry extends TileEntity implements IStreamable, IE
 	public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
 		if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
 			if (facing != null) {
-				SidedInvWrapper sidedInvWrapper = new SidedInvWrapper(inventory, facing);
+				SidedInvWrapper sidedInvWrapper = new SidedInvWrapper(getInternalInventory(), facing);
 				return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(sidedInvWrapper);
 			} else {
-				InvWrapper invWrapper = new InvWrapper(inventory);
+				InvWrapper invWrapper = new InvWrapper(getInternalInventory());
 				return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(invWrapper);
 			}
 


### PR DESCRIPTION
So I experienced the trader issue #1999 that inserting items automatically would not show up in the internal inventory. Yet after inserting 6 stacks of paper automatically, I could still put paper in manually, but no more paper could be inserted automatically.

I suspected that the trader actually had two inventories, one that is used for trading and shown in the manual GUI, and another where automatically inputted items go. 

It turns out that this was the case as TileTrader initially creates a dud InventoryTradeStation for itself, and overrides getInternalInventory() to return the actual inventory. As TileForestry used the field inventory instead of getInternalInventory() in its getCapability method, the dud inventory would be returned in the capability, rather than the actual one, thus inputted items would go to the dud inventory. By changing getCapability to use getInternalInventory() rather than the inventory field, this fixes the issue.