### PR TITLE
allow hive worldgen to scale 

### DIFF
--- a/src/main/java/forestry/apiculture/worldgen/HiveDecorator.java
+++ b/src/main/java/forestry/apiculture/worldgen/HiveDecorator.java
@@ -59,7 +59,7 @@ public abstract class HiveDecorator {
 
 		Collections.shuffle(hives, rand);
 
-		for (int tries = 0; tries < 4; tries++) {
+		for (int tries = 0; tries < hives.size() / 2; tries++) {
 			int x = worldX + rand.nextInt(16);
 			int z = worldZ + rand.nextInt(16);
 
@@ -72,7 +72,7 @@ public abstract class HiveDecorator {
 			EnumHumidity humidity = EnumHumidity.getFromValue(biome.getRainfall());
 
 			for (Hive hive : hives) {
-				if (hive.genChance() * Config.getBeehivesAmount() >= rand.nextFloat() * 100.0f) {
+				if (hive.genChance() * Config.getBeehivesAmount() * hives.size() / 8 >= rand.nextFloat() * 100.0f) {
 					if (hive.isGoodBiome(biome) && hive.isGoodHumidity(humidity)) {
 						if (tryGenHive(world, rand, x, z, hive)) {
 							return;


### PR DESCRIPTION
at the moment the numbers in `HiveDecorator` are fairly hardcoded. While working on https://github.com/ForestryMC/Binnie/pull/486 I realised that this makes it hard to get decent numbers of every hive. If this will make the world too busy with hives we can just ignore it but there won't be as many Binnies hives. Let me know what you think.