### PR TITLE
 add config for disabling factory machines 

### DIFF
--- a/src/main/java/forestry/api/fuels/DummyMap.java
+++ b/src/main/java/forestry/api/fuels/DummyMap.java
@@ -1,0 +1,4 @@
+package forestry.api.fuels;
+
+public class DummyMap {
+}

--- a/src/main/java/forestry/api/fuels/DummyMap.java
+++ b/src/main/java/forestry/api/fuels/DummyMap.java
@@ -1,4 +1,0 @@
-package forestry.api.fuels;
-
-public class DummyMap {
-}

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -42,6 +42,7 @@ import forestry.apiculture.HiveConfig;
 import forestry.core.fluids.Fluids;
 import forestry.core.utils.Log;
 import forestry.core.utils.Translator;
+import forestry.factory.ModuleFactory;
 import forestry.mail.gui.GuiMailboxInfo;
 
 public class Config {
@@ -389,6 +390,7 @@ public class Config {
 
 		energyDisplayMode = configCommon.getEnumLocalized("power.display", "mode", EnergyDisplayMode.RF, EnergyDisplayMode.values());
 
+		ModuleFactory.loadMachineConfig(configCommon);
 
 		configCommon.save();
 	}

--- a/src/main/java/forestry/core/config/LocalizedConfiguration.java
+++ b/src/main/java/forestry/core/config/LocalizedConfiguration.java
@@ -130,7 +130,7 @@ public class LocalizedConfiguration extends Configuration {
 		String defautValue = prop.isList() ? Arrays.toString(prop.getDefaults()) : prop.getDefault();
 		String ret = " [default: " + defautValue + "]";
 		if (prop.getValidValues().length != 0) {
-			ret += " [valid: " + Arrays.toString(prop.getValidValues())+"]";
+			ret += " [valid: " + Arrays.toString(prop.getValidValues()) + "]";
 		}
 		return ret;
 	}

--- a/src/main/java/forestry/core/recipes/jei/ForestryRecipeCategoryUid.java
+++ b/src/main/java/forestry/core/recipes/jei/ForestryRecipeCategoryUid.java
@@ -1,18 +1,16 @@
 package forestry.core.recipes.jei;
 
+import forestry.factory.MachineUIDs;
+
 public class ForestryRecipeCategoryUid {
 
-	private ForestryRecipeCategoryUid() {
-	}
-
-	public static final String BOTTLER = "forestry.bottler";
-	public static final String CARPENTER = "forestry.carpenter";
-	public static final String CENTRIFUGE = "forestry.centrifuge";
-	public static final String FABRICATOR = "forestry.fabricator";
-	public static final String FERMENTER = "forestry.fermenter";
-	public static final String MOISTENER = "forestry.moistener";
-	public static final String RAINMAKER = "forestry.rainmaker";
-	public static final String SQUEEZER = "forestry.squeezer";
-	public static final String STILL = "forestry.still";
-
+	public static final String BOTTLER = "forestry." + MachineUIDs.BOTTLER;
+	public static final String CARPENTER = "forestry." + MachineUIDs.CARPENTER;
+	public static final String CENTRIFUGE = "forestry." + MachineUIDs.CENTRIFUGE;
+	public static final String FABRICATOR = "forestry." + MachineUIDs.FABRICATOR;
+	public static final String FERMENTER = "forestry." + MachineUIDs.FERMENTER;
+	public static final String MOISTENER = "forestry." + MachineUIDs.MOISTENER;
+	public static final String RAINMAKER = "forestry." + MachineUIDs.RAINMAKER;
+	public static final String SQUEEZER = "forestry." + MachineUIDs.SQUEEZER;
+	public static final String STILL = "forestry." + MachineUIDs.STILL;
 }

--- a/src/main/java/forestry/core/utils/datastructures/DummyMap.java
+++ b/src/main/java/forestry/core/utils/datastructures/DummyMap.java
@@ -1,0 +1,75 @@
+package forestry.core.utils.datastructures;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A map that doesn't actually store anything
+ */
+public class DummyMap<K, V> implements Map<K, V> {
+	@Override
+	public int size() {
+		return 0;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return true;
+	}
+
+	@Override
+	public boolean containsKey(Object o) {
+		return false;
+	}
+
+	@Override
+	public boolean containsValue(Object o) {
+		return false;
+	}
+
+	@Override
+	@Nullable
+	public V get(Object o) {
+		return null;
+	}
+
+	@Override
+	@Nullable
+	public V put(K k, V v) {
+		return null;
+	}
+
+	@Override
+	@Nullable
+	public V remove(Object o) {
+		return null;
+	}
+
+	@Override
+	public void putAll(Map<? extends K, ? extends V> map) {
+
+	}
+
+	@Override
+	public void clear() {
+
+	}
+
+	@Override
+	public Set<K> keySet() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public Collection<V> values() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public Set<Entry<K, V>> entrySet() {
+		return Collections.emptySet();
+	}
+}

--- a/src/main/java/forestry/factory/MachineUIDs.java
+++ b/src/main/java/forestry/factory/MachineUIDs.java
@@ -1,0 +1,24 @@
+package forestry.factory;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+
+public class MachineUIDs {
+
+	private MachineUIDs() {}
+
+	public static final String BOTTLER = "bottler";
+	public static final String CARPENTER = "carpenter";
+	public static final String CENTRIFUGE = "centrifuge";
+	public static final String FABRICATOR = "fabricator";
+	public static final String FERMENTER = "fermenter";
+	public static final String MOISTENER = "moistener";
+	public static final String RAINMAKER = "rainmaker";
+	public static final String RAINTANK = "raintank";
+	public static final String SQUEEZER = "squeezer";
+	public static final String STILL = "still";
+
+	public static final Set<String> ALL = Sets.newHashSet(BOTTLER, CARPENTER, CENTRIFUGE, FABRICATOR,
+			FERMENTER, MOISTENER, RAINMAKER, RAINTANK, SQUEEZER, STILL);
+}

--- a/src/main/java/forestry/factory/ModuleFactory.java
+++ b/src/main/java/forestry/factory/ModuleFactory.java
@@ -86,7 +86,6 @@ import forestry.storage.ModuleCrates;
 public class ModuleFactory extends BlankForestryModule {
 
 	public static final Map<String, Boolean> MACHINE_ENABLED = Maps.newHashMap();
-	public static final Map<String, Boolean> MACHINE_RECIPES_ENABLED = Maps.newHashMap();
 
 	@Nullable
 	private static BlockRegistryFactory blocks;
@@ -98,14 +97,14 @@ public class ModuleFactory extends BlankForestryModule {
 
 	@Override
 	public void setupAPI() {
-		RecipeManagers.carpenterManager = machineRecipesEnabled(MachineUIDs.CARPENTER) ? new CarpenterRecipeManager() : new DummyManagers.DummyCarpenterManager();
-		RecipeManagers.centrifugeManager = machineRecipesEnabled(MachineUIDs.CENTRIFUGE) ? new CentrifugeRecipeManager() : new DummyManagers.DummyCentrifugeManager();
-		RecipeManagers.fabricatorManager = machineRecipesEnabled(MachineUIDs.FABRICATOR) ? new FabricatorRecipeManager() : new DummyManagers.DummyFabricatorManager();
-		RecipeManagers.fabricatorSmeltingManager = machineRecipesEnabled(MachineUIDs.FABRICATOR) ? new FabricatorSmeltingRecipeManager() : new DummyManagers.DummyFabricatorSmeltingManager();
-		RecipeManagers.fermenterManager = machineRecipesEnabled(MachineUIDs.FERMENTER) ? new FermenterRecipeManager() : new DummyManagers.DummyFermenterManager();
-		RecipeManagers.moistenerManager = machineRecipesEnabled(MachineUIDs.MOISTENER) ? new MoistenerRecipeManager() : new DummyManagers.DummyMoistenerManager();
-		RecipeManagers.squeezerManager = machineRecipesEnabled(MachineUIDs.SQUEEZER) ? new SqueezerRecipeManager() : new DummyManagers.DummySqueezerManager();
-		RecipeManagers.stillManager = machineRecipesEnabled(MachineUIDs.STILL) ? new StillRecipeManager() : new DummyManagers.DummyStillManager();
+		RecipeManagers.carpenterManager = machineEnabled(MachineUIDs.CARPENTER) ? new CarpenterRecipeManager() : new DummyManagers.DummyCarpenterManager();
+		RecipeManagers.centrifugeManager = machineEnabled(MachineUIDs.CENTRIFUGE) ? new CentrifugeRecipeManager() : new DummyManagers.DummyCentrifugeManager();
+		RecipeManagers.fabricatorManager = machineEnabled(MachineUIDs.FABRICATOR) ? new FabricatorRecipeManager() : new DummyManagers.DummyFabricatorManager();
+		RecipeManagers.fabricatorSmeltingManager = machineEnabled(MachineUIDs.FABRICATOR) ? new FabricatorSmeltingRecipeManager() : new DummyManagers.DummyFabricatorSmeltingManager();
+		RecipeManagers.fermenterManager = machineEnabled(MachineUIDs.FERMENTER) ? new FermenterRecipeManager() : new DummyManagers.DummyFermenterManager();
+		RecipeManagers.moistenerManager = machineEnabled(MachineUIDs.MOISTENER) ? new MoistenerRecipeManager() : new DummyManagers.DummyMoistenerManager();
+		RecipeManagers.squeezerManager = machineEnabled(MachineUIDs.SQUEEZER) ? new SqueezerRecipeManager() : new DummyManagers.DummySqueezerManager();
+		RecipeManagers.stillManager = machineEnabled(MachineUIDs.STILL) ? new StillRecipeManager() : new DummyManagers.DummyStillManager();
 
 		setupFuelManager();
 	}
@@ -125,8 +124,8 @@ public class ModuleFactory extends BlankForestryModule {
 	}
 
 	private static void setupFuelManager() {
-		FuelManager.fermenterFuel = machineRecipesEnabled(MachineUIDs.FERMENTER) ? new ItemStackMap<>() : new DummyMap<>();
-		FuelManager.moistenerResource = machineRecipesEnabled(MachineUIDs.MOISTENER) ? new ItemStackMap<>() : new DummyMap<>();
+		FuelManager.fermenterFuel = machineEnabled(MachineUIDs.FERMENTER) ? new ItemStackMap<>() : new DummyMap<>();
+		FuelManager.moistenerResource = machineEnabled(MachineUIDs.MOISTENER) ? new ItemStackMap<>() : new DummyMap<>();
 		FuelManager.rainSubstrate = machineEnabled(MachineUIDs.RAINMAKER) ? new ItemStackMap<>() : new DummyMap<>();
 		FuelManager.bronzeEngineFuel = new FluidMap<>();
 		FuelManager.copperEngineFuel = new ItemStackMap<>();
@@ -679,23 +678,13 @@ public class ModuleFactory extends BlankForestryModule {
 
 	public static void loadMachineConfig(LocalizedConfiguration config) {
 		List<String> enabled = Arrays.asList(config.getStringListLocalized("machines", "enabled", MachineUIDs.ALL.toArray(new String[0]), MachineUIDs.ALL.toArray(new String[0])));
-		List<String> recipesEnabled = Arrays.asList(config.getStringListLocalizedFormatted("machines", "recipes_enabled", MachineUIDs.ALL.toArray(new String[0]), MachineUIDs.ALL.toArray(new String[0]), "\n"));
 		for (String machineID : MachineUIDs.ALL) {
 			MACHINE_ENABLED.put(machineID, enabled.contains(machineID));
-			if(machineID.equals(MachineUIDs.BOTTLER)) {
-				continue;	//bottler doesn't have a recipe map.
-			}
-			MACHINE_RECIPES_ENABLED.put(machineID, recipesEnabled.contains(machineID));
 		}
 	}
 
 	public static boolean machineEnabled(String machineName) {
 		Boolean ret = MACHINE_ENABLED.get(machineName);
-		return ret != null && ret;
-	}
-
-	public static boolean machineRecipesEnabled(String machineName) {
-		Boolean ret = MACHINE_RECIPES_ENABLED.get(machineName);
 		return ret != null && ret;
 	}
 }

--- a/src/main/java/forestry/factory/ModuleFactory.java
+++ b/src/main/java/forestry/factory/ModuleFactory.java
@@ -11,8 +11,12 @@
 package forestry.factory;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import net.minecraft.block.BlockDirt.DirtType;
@@ -50,6 +54,7 @@ import forestry.core.circuits.Circuits;
 import forestry.core.circuits.EnumCircuitBoardType;
 import forestry.core.circuits.ItemCircuitBoard;
 import forestry.core.config.Constants;
+import forestry.core.config.LocalizedConfiguration;
 import forestry.core.fluids.Fluids;
 import forestry.core.items.EnumElectronTube;
 import forestry.core.items.ItemElectronTube;
@@ -58,6 +63,7 @@ import forestry.core.items.ItemRegistryFluids;
 import forestry.core.network.IPacketRegistry;
 import forestry.core.recipes.RecipeUtil;
 import forestry.core.utils.OreDictUtil;
+import forestry.core.utils.datastructures.DummyMap;
 import forestry.core.utils.datastructures.FluidMap;
 import forestry.core.utils.datastructures.ItemStackMap;
 import forestry.factory.blocks.BlockRegistryFactory;
@@ -78,6 +84,10 @@ import forestry.storage.ModuleCrates;
 
 @ForestryModule(containerID = Constants.MOD_ID, moduleID = ForestryModuleUids.FACTORY, name = "Factory", author = "SirSengir", url = Constants.URL, unlocalizedDescription = "for.module.factory.description", lootTable = "factory")
 public class ModuleFactory extends BlankForestryModule {
+
+	public static final Map<String, Boolean> MACHINE_ENABLED = Maps.newHashMap();
+	public static final Map<String, Boolean> MACHINE_RECIPES_ENABLED = Maps.newHashMap();
+
 	@Nullable
 	private static BlockRegistryFactory blocks;
 
@@ -88,14 +98,14 @@ public class ModuleFactory extends BlankForestryModule {
 
 	@Override
 	public void setupAPI() {
-		RecipeManagers.carpenterManager = new CarpenterRecipeManager();
-		RecipeManagers.centrifugeManager = new CentrifugeRecipeManager();
-		RecipeManagers.fabricatorManager = new FabricatorRecipeManager();
-		RecipeManagers.fabricatorSmeltingManager = new FabricatorSmeltingRecipeManager();
-		RecipeManagers.fermenterManager = new FermenterRecipeManager();
-		RecipeManagers.moistenerManager = new MoistenerRecipeManager();
-		RecipeManagers.squeezerManager = new SqueezerRecipeManager();
-		RecipeManagers.stillManager = new StillRecipeManager();
+		RecipeManagers.carpenterManager = machineRecipesEnabled(MachineUIDs.CARPENTER) ? new CarpenterRecipeManager() : new DummyManagers.DummyCarpenterManager();
+		RecipeManagers.centrifugeManager = machineRecipesEnabled(MachineUIDs.CENTRIFUGE) ? new CentrifugeRecipeManager() : new DummyManagers.DummyCentrifugeManager();
+		RecipeManagers.fabricatorManager = machineRecipesEnabled(MachineUIDs.FABRICATOR) ? new FabricatorRecipeManager() : new DummyManagers.DummyFabricatorManager();
+		RecipeManagers.fabricatorSmeltingManager = machineRecipesEnabled(MachineUIDs.FABRICATOR) ? new FabricatorSmeltingRecipeManager() : new DummyManagers.DummyFabricatorSmeltingManager();
+		RecipeManagers.fermenterManager = machineRecipesEnabled(MachineUIDs.FERMENTER) ? new FermenterRecipeManager() : new DummyManagers.DummyFermenterManager();
+		RecipeManagers.moistenerManager = machineRecipesEnabled(MachineUIDs.MOISTENER) ? new MoistenerRecipeManager() : new DummyManagers.DummyMoistenerManager();
+		RecipeManagers.squeezerManager = machineRecipesEnabled(MachineUIDs.SQUEEZER) ? new SqueezerRecipeManager() : new DummyManagers.DummySqueezerManager();
+		RecipeManagers.stillManager = machineRecipesEnabled(MachineUIDs.STILL) ? new StillRecipeManager() : new DummyManagers.DummyStillManager();
 
 		setupFuelManager();
 	}
@@ -115,9 +125,9 @@ public class ModuleFactory extends BlankForestryModule {
 	}
 
 	private static void setupFuelManager() {
-		FuelManager.fermenterFuel = new ItemStackMap<>();
-		FuelManager.moistenerResource = new ItemStackMap<>();
-		FuelManager.rainSubstrate = new ItemStackMap<>();
+		FuelManager.fermenterFuel = machineRecipesEnabled(MachineUIDs.FERMENTER) ? new ItemStackMap<>() : new DummyMap<>();
+		FuelManager.moistenerResource = machineRecipesEnabled(MachineUIDs.MOISTENER) ? new ItemStackMap<>() : new DummyMap<>();
+		FuelManager.rainSubstrate = machineEnabled(MachineUIDs.RAINMAKER) ? new ItemStackMap<>() : new DummyMap<>();
 		FuelManager.bronzeEngineFuel = new FluidMap<>();
 		FuelManager.copperEngineFuel = new ItemStackMap<>();
 		FuelManager.generatorFuel = new FluidMap<>();
@@ -390,13 +400,13 @@ public class ModuleFactory extends BlankForestryModule {
 		iceRecipeResources.add(new ItemStack(Items.SNOWBALL));
 		iceRecipeResources.add(coreItems.craftingMaterial.getIceShard(4));
 		FluidStack liquidIce = Fluids.ICE.getFluid(4000);
-		if(liquidIce != null) {
+		if (liquidIce != null) {
 			RecipeManagers.squeezerManager.addRecipe(10, iceRecipeResources, liquidIce);
 		}
 		// STILL
 		FluidStack biomass = Fluids.BIOMASS.getFluid(Constants.STILL_DESTILLATION_INPUT);
 		FluidStack ethanol = Fluids.BIO_ETHANOL.getFluid(Constants.STILL_DESTILLATION_OUTPUT);
-		if(biomass != null && ethanol != null) {
+		if (biomass != null && ethanol != null) {
 			RecipeManagers.stillManager.addRecipe(Constants.STILL_DESTILLATION_DURATION, biomass, ethanol);
 		}
 		// MOISTENER
@@ -417,7 +427,7 @@ public class ModuleFactory extends BlankForestryModule {
 
 		// FABRICATOR
 		FluidStack liquidGlass375 = Fluids.GLASS.getFluid(375);
-		if(liquidGlass375 != null && liquidGlassBucket != null && liquidGlassX4 != null) {
+		if (liquidGlass375 != null && liquidGlassBucket != null && liquidGlassX4 != null) {
 			RecipeManagers.fabricatorSmeltingManager.addSmelting(new ItemStack(Blocks.GLASS), liquidGlassBucket, 1000);
 			RecipeManagers.fabricatorSmeltingManager.addSmelting(new ItemStack(Blocks.GLASS_PANE), liquidGlass375, 1000);
 			RecipeManagers.fabricatorSmeltingManager.addSmelting(new ItemStack(Blocks.SAND), liquidGlassBucket, 3000);
@@ -560,90 +570,133 @@ public class ModuleFactory extends BlankForestryModule {
 		ICircuitLayout layout = ChipsetManager.circuitRegistry.getLayout("forestry.machine.upgrade");
 
 		// / Solder Manager
-		if(layout != null) {
+		if (layout != null) {
 			ChipsetManager.solderManager.addRecipe(layout, coreItems.tubes.get(EnumElectronTube.EMERALD, 1), Circuits.machineSpeedUpgrade1);
 			ChipsetManager.solderManager.addRecipe(layout, coreItems.tubes.get(EnumElectronTube.BLAZE, 1), Circuits.machineSpeedUpgrade2);
 			ChipsetManager.solderManager.addRecipe(layout, coreItems.tubes.get(EnumElectronTube.GOLD, 1), Circuits.machineEfficiencyUpgrade1);
 		}
-		RecipeUtil.addRecipe("bottler", blocks.bottler,
-				"X#X",
-				"#Y#",
-				"X#X",
-				'#', "blockGlass",
-				'X', fluidItems.canEmpty,
-				'Y', coreItems.sturdyCasing);
+		if (machineEnabled(MachineUIDs.BOTTLER)) {
+			RecipeUtil.addRecipe(MachineUIDs.BOTTLER, blocks.bottler,
+					"X#X",
+					"#Y#",
+					"X#X",
+					'#', "blockGlass",
+					'X', fluidItems.canEmpty,
+					'Y', coreItems.sturdyCasing);
+		}
 
-		RecipeUtil.addRecipe("carpenter", blocks.carpenter,
-				"X#X",
-				"XYX",
-				"X#X",
-				'#', "blockGlass",
-				'X', "ingotBronze",
-				'Y', coreItems.sturdyCasing);
+		if (machineEnabled(MachineUIDs.CARPENTER)) {
+			RecipeUtil.addRecipe(MachineUIDs.CARPENTER, blocks.carpenter,
+					"X#X",
+					"XYX",
+					"X#X",
+					'#', "blockGlass",
+					'X', "ingotBronze",
+					'Y', coreItems.sturdyCasing);
+		}
 
-		RecipeUtil.addRecipe("centrifuge", blocks.centrifuge,
-				"X#X",
-				"XYX",
-				"X#X",
-				'#', "blockGlass",
-				'X', "ingotCopper",
-				'Y', coreItems.sturdyCasing);
+		if (machineEnabled(MachineUIDs.CENTRIFUGE)) {
+			RecipeUtil.addRecipe(MachineUIDs.CENTRIFUGE, blocks.centrifuge,
+					"X#X",
+					"XYX",
+					"X#X",
+					'#', "blockGlass",
+					'X', "ingotCopper",
+					'Y', coreItems.sturdyCasing);
+		}
 
-		RecipeUtil.addRecipe("fermenter", blocks.fermenter,
-				"X#X",
-				"#Y#",
-				"X#X",
-				'#', "blockGlass",
-				'X', "gearBronze",
-				'Y', coreItems.sturdyCasing);
+		if (machineEnabled(MachineUIDs.FERMENTER)) {
+			RecipeUtil.addRecipe(MachineUIDs.FERMENTER, blocks.fermenter,
+					"X#X",
+					"#Y#",
+					"X#X",
+					'#', "blockGlass",
+					'X', "gearBronze",
+					'Y', coreItems.sturdyCasing);
+		}
 
-		RecipeUtil.addRecipe("moistener", blocks.moistener,
-				"X#X",
-				"#Y#",
-				"X#X",
-				'#', "blockGlass",
-				'X', "gearCopper",
-				'Y', coreItems.sturdyCasing);
+		if (machineEnabled(MachineUIDs.MOISTENER)) {
+			RecipeUtil.addRecipe(MachineUIDs.MOISTENER, blocks.moistener,
+					"X#X",
+					"#Y#",
+					"X#X",
+					'#', "blockGlass",
+					'X', "gearCopper",
+					'Y', coreItems.sturdyCasing);
+		}
 
-		RecipeUtil.addRecipe("squeezer", blocks.squeezer,
-				"X#X",
-				"XYX",
-				"X#X",
-				'#', "blockGlass",
-				'X', "ingotTin",
-				'Y', coreItems.sturdyCasing);
+		if (machineEnabled(MachineUIDs.SQUEEZER)) {
+			RecipeUtil.addRecipe(MachineUIDs.SQUEEZER, blocks.squeezer,
+					"X#X",
+					"XYX",
+					"X#X",
+					'#', "blockGlass",
+					'X', "ingotTin",
+					'Y', coreItems.sturdyCasing);
+		}
 
-		RecipeUtil.addRecipe("still", blocks.still,
-				"X#X",
-				"#Y#",
-				"X#X",
-				'#', "blockGlass",
-				'X', "dustRedstone",
-				'Y', coreItems.sturdyCasing);
+		if (machineEnabled(MachineUIDs.STILL)) {
+			RecipeUtil.addRecipe(MachineUIDs.STILL, blocks.still,
+					"X#X",
+					"#Y#",
+					"X#X",
+					'#', "blockGlass",
+					'X', "dustRedstone",
+					'Y', coreItems.sturdyCasing);
+		}
 
-		RecipeUtil.addRecipe("rainmaker", blocks.rainmaker,
-				"X#X",
-				"#Y#",
-				"X#X",
-				'#', "blockGlass",
-				'X', "gearTin",
-				'Y', coreItems.hardenedCasing);
+		if (machineEnabled(MachineUIDs.RAINMAKER)) {
+			RecipeUtil.addRecipe(MachineUIDs.RAINMAKER, blocks.rainmaker,
+					"X#X",
+					"#Y#",
+					"X#X",
+					'#', "blockGlass",
+					'X', "gearTin",
+					'Y', coreItems.hardenedCasing);
+		}
 
-		RecipeUtil.addRecipe("fabricator", blocks.fabricator,
-				"X#X",
-				"#Y#",
-				"XZX",
-				'#', "blockGlass",
-				'X', "ingotGold",
-				'Y', coreItems.sturdyCasing,
-				'Z', "chestWood");
+		if (machineEnabled(MachineUIDs.FABRICATOR)) {
+			RecipeUtil.addRecipe(MachineUIDs.FABRICATOR, blocks.fabricator,
+					"X#X",
+					"#Y#",
+					"XZX",
+					'#', "blockGlass",
+					'X', "ingotGold",
+					'Y', coreItems.sturdyCasing,
+					'Z', "chestWood");
+		}
 
-		RecipeUtil.addRecipe("raintank", blocks.raintank,
-				"X#X",
-				"XYX",
-				"X#X",
-				'#', "blockGlass",
-				'X', "ingotIron",
-				'Y', coreItems.sturdyCasing);
+		if (machineEnabled(MachineUIDs.RAINTANK)) {
+			RecipeUtil.addRecipe(MachineUIDs.RAINTANK, blocks.raintank,
+					"X#X",
+					"XYX",
+					"X#X",
+					'#', "blockGlass",
+					'X', "ingotIron",
+					'Y', coreItems.sturdyCasing);
+		}
+	}
+
+	public static void loadMachineConfig(LocalizedConfiguration config) {
+		List<String> enabled = Arrays.asList(config.getStringListLocalized("machines", "enabled", MachineUIDs.ALL.toArray(new String[0]), MachineUIDs.ALL.toArray(new String[0])));
+		List<String> recipesEnabled = Arrays.asList(config.getStringListLocalizedFormatted("machines", "recipes_enabled", MachineUIDs.ALL.toArray(new String[0]), MachineUIDs.ALL.toArray(new String[0]), "\n"));
+		for (String machineID : MachineUIDs.ALL) {
+			MACHINE_ENABLED.put(machineID, enabled.contains(machineID));
+			if(machineID.equals(MachineUIDs.BOTTLER)) {
+				continue;	//bottler doesn't have a recipe map.
+			}
+			MACHINE_RECIPES_ENABLED.put(machineID, recipesEnabled.contains(machineID));
+		}
+	}
+
+	public static boolean machineEnabled(String machineName) {
+		Boolean ret = MACHINE_ENABLED.get(machineName);
+		return ret != null && ret;
+	}
+
+	public static boolean machineRecipesEnabled(String machineName) {
+		Boolean ret = MACHINE_RECIPES_ENABLED.get(machineName);
+		return ret != null && ret;
 	}
 }
+

--- a/src/main/java/forestry/factory/blocks/BlockRegistryFactory.java
+++ b/src/main/java/forestry/factory/blocks/BlockRegistryFactory.java
@@ -13,6 +13,8 @@ package forestry.factory.blocks;
 import forestry.core.blocks.BlockRegistry;
 import forestry.core.items.ItemBlockForestry;
 import forestry.core.items.ItemBlockNBT;
+import forestry.factory.MachineUIDs;
+import forestry.factory.ModuleFactory;
 
 public class BlockRegistryFactory extends BlockRegistry {
 	public final BlockFactoryTESR bottler;
@@ -29,33 +31,53 @@ public class BlockRegistryFactory extends BlockRegistry {
 
 	public BlockRegistryFactory() {
 		bottler = new BlockFactoryTESR(BlockTypeFactoryTesr.BOTTLER);
-		registerBlock(bottler, new ItemBlockForestry<>(bottler), "bottler");
+		if (ModuleFactory.machineEnabled(MachineUIDs.BOTTLER)) {
+			registerBlock(bottler, new ItemBlockForestry<>(bottler), MachineUIDs.BOTTLER);
+		}
 
 		carpenter = new BlockFactoryTESR(BlockTypeFactoryTesr.CARPENTER);
-		registerBlock(carpenter, new ItemBlockForestry<>(carpenter), "carpenter");
+		if (ModuleFactory.machineEnabled(MachineUIDs.CARPENTER)) {
+			registerBlock(carpenter, new ItemBlockForestry<>(carpenter), MachineUIDs.CARPENTER);
+		}
 
 		centrifuge = new BlockFactoryTESR(BlockTypeFactoryTesr.CENTRIFUGE);
-		registerBlock(centrifuge, new ItemBlockForestry<>(centrifuge), "centrifuge");
+		if (ModuleFactory.machineEnabled(MachineUIDs.CENTRIFUGE)) {
+			registerBlock(centrifuge, new ItemBlockForestry<>(centrifuge), MachineUIDs.CENTRIFUGE);
+		}
 
 		fermenter = new BlockFactoryTESR(BlockTypeFactoryTesr.FERMENTER);
-		registerBlock(fermenter, new ItemBlockForestry<>(fermenter), "fermenter");
+		if (ModuleFactory.machineEnabled(MachineUIDs.FERMENTER)) {
+			registerBlock(fermenter, new ItemBlockForestry<>(fermenter), MachineUIDs.FERMENTER);
+		}
 
 		moistener = new BlockFactoryTESR(BlockTypeFactoryTesr.MOISTENER);
-		registerBlock(moistener, new ItemBlockForestry<>(moistener), "moistener");
+		if (ModuleFactory.machineEnabled(MachineUIDs.MOISTENER)) {
+			registerBlock(moistener, new ItemBlockForestry<>(moistener), MachineUIDs.MOISTENER);
+		}
 
 		squeezer = new BlockFactoryTESR(BlockTypeFactoryTesr.SQUEEZER);
-		registerBlock(squeezer, new ItemBlockForestry<>(squeezer), "squeezer");
+		if (ModuleFactory.machineEnabled(MachineUIDs.SQUEEZER)) {
+			registerBlock(squeezer, new ItemBlockForestry<>(squeezer), MachineUIDs.SQUEEZER);
+		}
 
 		still = new BlockFactoryTESR(BlockTypeFactoryTesr.STILL);
-		registerBlock(still, new ItemBlockForestry<>(still), "still");
+		if (ModuleFactory.machineEnabled(MachineUIDs.STILL)) {
+			registerBlock(still, new ItemBlockForestry<>(still), MachineUIDs.STILL);
+		}
 
 		rainmaker = new BlockFactoryTESR(BlockTypeFactoryTesr.RAINMAKER);
-		registerBlock(rainmaker, new ItemBlockForestry<>(rainmaker), "rainmaker");
+		if (ModuleFactory.machineEnabled(MachineUIDs.RAINMAKER)) {
+			registerBlock(rainmaker, new ItemBlockForestry<>(rainmaker), MachineUIDs.RAINMAKER);
+		}
 
 		fabricator = new BlockFactoryPlain(BlockTypeFactoryPlain.FABRICATOR);
-		registerBlock(fabricator, new ItemBlockNBT(fabricator), "fabricator");
+		if (ModuleFactory.machineEnabled(MachineUIDs.FABRICATOR)) {
+			registerBlock(fabricator, new ItemBlockNBT(fabricator), MachineUIDs.FABRICATOR);
+		}
 
 		raintank = new BlockFactoryPlain(BlockTypeFactoryPlain.RAINTANK);
-		registerBlock(raintank, new ItemBlockNBT(raintank), "raintank");
+		if (ModuleFactory.machineEnabled(MachineUIDs.RAINTANK)) {
+			registerBlock(raintank, new ItemBlockNBT(raintank), MachineUIDs.RAINTANK);
+		}
 	}
 }

--- a/src/main/java/forestry/factory/blocks/BlockRegistryFactory.java
+++ b/src/main/java/forestry/factory/blocks/BlockRegistryFactory.java
@@ -14,7 +14,6 @@ import forestry.core.blocks.BlockRegistry;
 import forestry.core.items.ItemBlockForestry;
 import forestry.core.items.ItemBlockNBT;
 import forestry.factory.MachineUIDs;
-import forestry.factory.ModuleFactory;
 
 public class BlockRegistryFactory extends BlockRegistry {
 	public final BlockFactoryTESR bottler;
@@ -31,53 +30,33 @@ public class BlockRegistryFactory extends BlockRegistry {
 
 	public BlockRegistryFactory() {
 		bottler = new BlockFactoryTESR(BlockTypeFactoryTesr.BOTTLER);
-		if (ModuleFactory.machineEnabled(MachineUIDs.BOTTLER)) {
-			registerBlock(bottler, new ItemBlockForestry<>(bottler), MachineUIDs.BOTTLER);
-		}
+		registerBlock(bottler, new ItemBlockForestry<>(bottler), MachineUIDs.BOTTLER);
 
 		carpenter = new BlockFactoryTESR(BlockTypeFactoryTesr.CARPENTER);
-		if (ModuleFactory.machineEnabled(MachineUIDs.CARPENTER)) {
-			registerBlock(carpenter, new ItemBlockForestry<>(carpenter), MachineUIDs.CARPENTER);
-		}
+		registerBlock(carpenter, new ItemBlockForestry<>(carpenter), MachineUIDs.CARPENTER);
 
 		centrifuge = new BlockFactoryTESR(BlockTypeFactoryTesr.CENTRIFUGE);
-		if (ModuleFactory.machineEnabled(MachineUIDs.CENTRIFUGE)) {
-			registerBlock(centrifuge, new ItemBlockForestry<>(centrifuge), MachineUIDs.CENTRIFUGE);
-		}
+		registerBlock(centrifuge, new ItemBlockForestry<>(centrifuge), MachineUIDs.CENTRIFUGE);
 
 		fermenter = new BlockFactoryTESR(BlockTypeFactoryTesr.FERMENTER);
-		if (ModuleFactory.machineEnabled(MachineUIDs.FERMENTER)) {
-			registerBlock(fermenter, new ItemBlockForestry<>(fermenter), MachineUIDs.FERMENTER);
-		}
+		registerBlock(fermenter, new ItemBlockForestry<>(fermenter), MachineUIDs.FERMENTER);
 
 		moistener = new BlockFactoryTESR(BlockTypeFactoryTesr.MOISTENER);
-		if (ModuleFactory.machineEnabled(MachineUIDs.MOISTENER)) {
-			registerBlock(moistener, new ItemBlockForestry<>(moistener), MachineUIDs.MOISTENER);
-		}
+		registerBlock(moistener, new ItemBlockForestry<>(moistener), MachineUIDs.MOISTENER);
 
 		squeezer = new BlockFactoryTESR(BlockTypeFactoryTesr.SQUEEZER);
-		if (ModuleFactory.machineEnabled(MachineUIDs.SQUEEZER)) {
-			registerBlock(squeezer, new ItemBlockForestry<>(squeezer), MachineUIDs.SQUEEZER);
-		}
+		registerBlock(squeezer, new ItemBlockForestry<>(squeezer), MachineUIDs.SQUEEZER);
 
 		still = new BlockFactoryTESR(BlockTypeFactoryTesr.STILL);
-		if (ModuleFactory.machineEnabled(MachineUIDs.STILL)) {
-			registerBlock(still, new ItemBlockForestry<>(still), MachineUIDs.STILL);
-		}
+		registerBlock(still, new ItemBlockForestry<>(still), MachineUIDs.STILL);
 
 		rainmaker = new BlockFactoryTESR(BlockTypeFactoryTesr.RAINMAKER);
-		if (ModuleFactory.machineEnabled(MachineUIDs.RAINMAKER)) {
-			registerBlock(rainmaker, new ItemBlockForestry<>(rainmaker), MachineUIDs.RAINMAKER);
-		}
+		registerBlock(rainmaker, new ItemBlockForestry<>(rainmaker), MachineUIDs.RAINMAKER);
 
 		fabricator = new BlockFactoryPlain(BlockTypeFactoryPlain.FABRICATOR);
-		if (ModuleFactory.machineEnabled(MachineUIDs.FABRICATOR)) {
-			registerBlock(fabricator, new ItemBlockNBT(fabricator), MachineUIDs.FABRICATOR);
-		}
+		registerBlock(fabricator, new ItemBlockNBT(fabricator), MachineUIDs.FABRICATOR);
 
 		raintank = new BlockFactoryPlain(BlockTypeFactoryPlain.RAINTANK);
-		if (ModuleFactory.machineEnabled(MachineUIDs.RAINTANK)) {
-			registerBlock(raintank, new ItemBlockNBT(raintank), MachineUIDs.RAINTANK);
-		}
+		registerBlock(raintank, new ItemBlockNBT(raintank), MachineUIDs.RAINTANK);
 	}
 }

--- a/src/main/java/forestry/factory/recipes/jei/FactoryJeiPlugin.java
+++ b/src/main/java/forestry/factory/recipes/jei/FactoryJeiPlugin.java
@@ -1,19 +1,23 @@
 package forestry.factory.recipes.jei;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 import javax.annotation.Nullable;
 import java.awt.Rectangle;
+import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
 
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import forestry.core.gui.GuiForestry;
 import forestry.core.recipes.jei.ForestryRecipeCategoryUid;
 import forestry.core.utils.JeiUtil;
+import forestry.factory.MachineUIDs;
 import forestry.factory.ModuleFactory;
 import forestry.factory.blocks.BlockRegistryFactory;
 import forestry.factory.gui.GuiBottler;
@@ -53,6 +57,7 @@ import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
 import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.gui.IAdvancedGuiHandler;
+import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import mezz.jei.api.recipe.transfer.IRecipeTransferRegistry;
 
@@ -71,70 +76,119 @@ public class FactoryJeiPlugin implements IModPlugin {
 		jeiHelpers = registry.getJeiHelpers();
 		IGuiHelper guiHelper = jeiHelpers.getGuiHelper();
 
+		List<IRecipeCategory> categories = new ArrayList<>();
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.BOTTLER)) {
+			categories.add(new BottlerRecipeCategory(guiHelper));
+		}
+		if(ModuleFactory.machineEnabled(MachineUIDs.CARPENTER)) {
+			categories.add(new CarpenterRecipeCategory(guiHelper));
+		}
+		if(ModuleFactory.machineEnabled(MachineUIDs.CENTRIFUGE)) {
+			categories.add(new CentrifugeRecipeCategory(guiHelper));
+		}
+		if(ModuleFactory.machineEnabled(MachineUIDs.FABRICATOR)) {
+			categories.add(new FabricatorRecipeCategory(guiHelper));
+		}
+		if(ModuleFactory.machineEnabled(MachineUIDs.FERMENTER)) {
+			categories.add(new FermenterRecipeCategory(guiHelper));
+		}
+		if(ModuleFactory.machineEnabled(MachineUIDs.MOISTENER)) {
+			categories.add(new MoistenerRecipeCategory(guiHelper));
+		}
+		if(ModuleFactory.machineEnabled(MachineUIDs.RAINMAKER)) {
+			categories.add(new RainmakerRecipeCategory(guiHelper));
+		}
+		if(ModuleFactory.machineEnabled(MachineUIDs.SQUEEZER)) {
+			categories.add(new SqueezerRecipeCategory(guiHelper));
+		}
+		if(ModuleFactory.machineEnabled(MachineUIDs.STILL)) {
+			categories.add(new StillRecipeCategory(guiHelper));
+		}
+
 		registry.addRecipeCategories(
-				new BottlerRecipeCategory(guiHelper),
-				new CarpenterRecipeCategory(guiHelper),
-				new CentrifugeRecipeCategory(guiHelper),
-				new FabricatorRecipeCategory(guiHelper),
-				new FermenterRecipeCategory(guiHelper),
-				new MoistenerRecipeCategory(guiHelper),
-				new RainmakerRecipeCategory(guiHelper),
-				new SqueezerRecipeCategory(guiHelper),
-				new StillRecipeCategory(guiHelper)
+				categories.toArray(new IRecipeCategory[0])
 		);
 	}
 
 	@Override
 	public void register(IModRegistry registry) {
-		registry.addAdvancedGuiHandlers(new ForestryAdvancedGuiHandler());
-
 		if (!ModuleHelper.isEnabled(ForestryModuleUids.FACTORY)) {
 			return;
 		}
+		registry.addAdvancedGuiHandlers(new ForestryAdvancedGuiHandler());
+
+
 		jeiHelpers = registry.getJeiHelpers();
-
-		registry.addRecipes(BottlerRecipeMaker.getBottlerRecipes(registry.getIngredientRegistry()), ForestryRecipeCategoryUid.BOTTLER);
-		registry.addRecipes(CarpenterRecipeMaker.getCarpenterRecipes(), ForestryRecipeCategoryUid.CARPENTER);
-		registry.addRecipes(CentrifugeRecipeMaker.getCentrifugeRecipe(), ForestryRecipeCategoryUid.CENTRIFUGE);
-		registry.addRecipes(FabricatorRecipeMaker.getFabricatorRecipes(), ForestryRecipeCategoryUid.FABRICATOR);
-		registry.addRecipes(FermenterRecipeMaker.getFermenterRecipes(jeiHelpers.getStackHelper()), ForestryRecipeCategoryUid.FERMENTER);
-		registry.addRecipes(MoistenerRecipeMaker.getMoistenerRecipes(), ForestryRecipeCategoryUid.MOISTENER);
-		registry.addRecipes(RainmakerRecipeMaker.getRecipes(), ForestryRecipeCategoryUid.RAINMAKER);
-		registry.addRecipes(SqueezerRecipeMaker.getSqueezerRecipes(), ForestryRecipeCategoryUid.SQUEEZER);
-		registry.addRecipes(SqueezerRecipeMaker.getSqueezerContainerRecipes(registry.getIngredientRegistry()), ForestryRecipeCategoryUid.SQUEEZER);
-		registry.addRecipes(StillRecipeMaker.getStillRecipes(), ForestryRecipeCategoryUid.STILL);
-
-		registry.addRecipeClickArea(GuiBottler.class, 107, 33, 26, 22, ForestryRecipeCategoryUid.BOTTLER);
-		registry.addRecipeClickArea(GuiBottler.class, 45, 33, 26, 22, ForestryRecipeCategoryUid.BOTTLER);
-		registry.addRecipeClickArea(GuiCarpenter.class, 98, 48, 21, 26, ForestryRecipeCategoryUid.CARPENTER);
-		registry.addRecipeClickArea(GuiCentrifuge.class, 38, 22, 38, 14, ForestryRecipeCategoryUid.CENTRIFUGE);
-		registry.addRecipeClickArea(GuiCentrifuge.class, 38, 54, 38, 14, ForestryRecipeCategoryUid.CENTRIFUGE);
-		registry.addRecipeClickArea(GuiFabricator.class, 121, 53, 18, 18, ForestryRecipeCategoryUid.FABRICATOR);
-		registry.addRecipeClickArea(GuiFermenter.class, 72, 40, 32, 18, ForestryRecipeCategoryUid.FERMENTER);
-		registry.addRecipeClickArea(GuiMoistener.class, 123, 35, 19, 21, ForestryRecipeCategoryUid.MOISTENER);
-		registry.addRecipeClickArea(GuiSqueezer.class, 76, 41, 43, 16, ForestryRecipeCategoryUid.SQUEEZER);
-		registry.addRecipeClickArea(GuiStill.class, 73, 17, 33, 57, ForestryRecipeCategoryUid.STILL);
 
 		BlockRegistryFactory blocks = ModuleFactory.getBlocks();
 		Preconditions.checkNotNull(blocks);
 
-		registry.addRecipeCatalyst(new ItemStack(blocks.bottler), ForestryRecipeCategoryUid.BOTTLER);
-		registry.addRecipeCatalyst(new ItemStack(blocks.carpenter), ForestryRecipeCategoryUid.CARPENTER);
-		registry.addRecipeCatalyst(new ItemStack(blocks.centrifuge), ForestryRecipeCategoryUid.CENTRIFUGE);
-		registry.addRecipeCatalyst(new ItemStack(blocks.fabricator), ForestryRecipeCategoryUid.FABRICATOR);
-		registry.addRecipeCatalyst(new ItemStack(blocks.fermenter), ForestryRecipeCategoryUid.FERMENTER);
-		registry.addRecipeCatalyst(new ItemStack(blocks.moistener), ForestryRecipeCategoryUid.MOISTENER);
-		registry.addRecipeCatalyst(new ItemStack(blocks.rainmaker), ForestryRecipeCategoryUid.RAINMAKER);
-		registry.addRecipeCatalyst(new ItemStack(blocks.squeezer), ForestryRecipeCategoryUid.SQUEEZER);
-		registry.addRecipeCatalyst(new ItemStack(blocks.still), ForestryRecipeCategoryUid.STILL);
-
 		IRecipeTransferRegistry transferRegistry = registry.getRecipeTransferRegistry();
-		transferRegistry.addRecipeTransferHandler(new CarpenterRecipeTransferHandler(), ForestryRecipeCategoryUid.CARPENTER);
-		transferRegistry.addRecipeTransferHandler(new FabricatorRecipeTransferHandler(), ForestryRecipeCategoryUid.FABRICATOR);
 
-		JeiUtil.addDescription(registry,
-				blocks.raintank
-		);
+		if(ModuleFactory.machineEnabled(MachineUIDs.BOTTLER)) {
+			registry.addRecipes(BottlerRecipeMaker.getBottlerRecipes(registry.getIngredientRegistry()), ForestryRecipeCategoryUid.BOTTLER);
+			registry.addRecipeClickArea(GuiBottler.class, 107, 33, 26, 22, ForestryRecipeCategoryUid.BOTTLER);
+			registry.addRecipeClickArea(GuiBottler.class, 45, 33, 26, 22, ForestryRecipeCategoryUid.BOTTLER);
+			registry.addRecipeCatalyst(new ItemStack(blocks.bottler), ForestryRecipeCategoryUid.BOTTLER);
+
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.CARPENTER)) {
+			registry.addRecipes(CarpenterRecipeMaker.getCarpenterRecipes(), ForestryRecipeCategoryUid.CARPENTER);
+			registry.addRecipeClickArea(GuiCarpenter.class, 98, 48, 21, 26, ForestryRecipeCategoryUid.CARPENTER);
+			registry.addRecipeCatalyst(new ItemStack(blocks.carpenter), ForestryRecipeCategoryUid.CARPENTER);
+			transferRegistry.addRecipeTransferHandler(new CarpenterRecipeTransferHandler(), ForestryRecipeCategoryUid.CARPENTER);
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.CENTRIFUGE)) {
+			registry.addRecipes(CentrifugeRecipeMaker.getCentrifugeRecipe(), ForestryRecipeCategoryUid.CENTRIFUGE);
+			registry.addRecipeClickArea(GuiCentrifuge.class, 38, 22, 38, 14, ForestryRecipeCategoryUid.CENTRIFUGE);
+			registry.addRecipeClickArea(GuiCentrifuge.class, 38, 54, 38, 14, ForestryRecipeCategoryUid.CENTRIFUGE);
+			registry.addRecipeCatalyst(new ItemStack(blocks.centrifuge), ForestryRecipeCategoryUid.CENTRIFUGE);
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.FABRICATOR)) {
+			registry.addRecipes(FabricatorRecipeMaker.getFabricatorRecipes(), ForestryRecipeCategoryUid.FABRICATOR);
+			registry.addRecipeClickArea(GuiFabricator.class, 121, 53, 18, 18, ForestryRecipeCategoryUid.FABRICATOR);
+			registry.addRecipeCatalyst(new ItemStack(blocks.fabricator), ForestryRecipeCategoryUid.FABRICATOR);
+			transferRegistry.addRecipeTransferHandler(new FabricatorRecipeTransferHandler(), ForestryRecipeCategoryUid.FABRICATOR);
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.FERMENTER)) {
+			registry.addRecipes(FermenterRecipeMaker.getFermenterRecipes(jeiHelpers.getStackHelper()), ForestryRecipeCategoryUid.FERMENTER);
+			registry.addRecipeClickArea(GuiFermenter.class, 72, 40, 32, 18, ForestryRecipeCategoryUid.FERMENTER);
+			registry.addRecipeCatalyst(new ItemStack(blocks.fermenter), ForestryRecipeCategoryUid.FERMENTER);
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.MOISTENER)) {
+			registry.addRecipes(MoistenerRecipeMaker.getMoistenerRecipes(), ForestryRecipeCategoryUid.MOISTENER);
+			registry.addRecipeClickArea(GuiMoistener.class, 123, 35, 19, 21, ForestryRecipeCategoryUid.MOISTENER);
+			registry.addRecipeCatalyst(new ItemStack(blocks.moistener), ForestryRecipeCategoryUid.MOISTENER);
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.RAINMAKER)) {
+			registry.addRecipes(RainmakerRecipeMaker.getRecipes(), ForestryRecipeCategoryUid.RAINMAKER);
+			registry.addRecipeCatalyst(new ItemStack(blocks.rainmaker), ForestryRecipeCategoryUid.RAINMAKER);
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.SQUEEZER)) {
+			registry.addRecipes(SqueezerRecipeMaker.getSqueezerRecipes(), ForestryRecipeCategoryUid.SQUEEZER);
+			registry.addRecipes(SqueezerRecipeMaker.getSqueezerContainerRecipes(registry.getIngredientRegistry()), ForestryRecipeCategoryUid.SQUEEZER);
+			registry.addRecipeClickArea(GuiSqueezer.class, 76, 41, 43, 16, ForestryRecipeCategoryUid.SQUEEZER);
+			registry.addRecipeCatalyst(new ItemStack(blocks.squeezer), ForestryRecipeCategoryUid.SQUEEZER);
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.STILL)) {
+			registry.addRecipes(StillRecipeMaker.getStillRecipes(), ForestryRecipeCategoryUid.STILL);
+			registry.addRecipeClickArea(GuiStill.class, 73, 17, 33, 57, ForestryRecipeCategoryUid.STILL);
+			registry.addRecipeCatalyst(new ItemStack(blocks.still), ForestryRecipeCategoryUid.STILL);
+		}
+
+		if(ModuleFactory.machineEnabled(MachineUIDs.RAINTANK)) {
+			JeiUtil.addDescription(registry, blocks.raintank);
+		}
+
 	}
 
 	private static class ForestryAdvancedGuiHandler implements IAdvancedGuiHandler<GuiForestry> {

--- a/src/main/java/forestry/factory/recipes/jei/FactoryJeiPlugin.java
+++ b/src/main/java/forestry/factory/recipes/jei/FactoryJeiPlugin.java
@@ -1,7 +1,6 @@
 package forestry.factory.recipes.jei;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 
 import javax.annotation.Nullable;
 import java.awt.Rectangle;
@@ -10,7 +9,6 @@ import java.util.List;
 
 import net.minecraft.item.ItemStack;
 
-import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -78,37 +76,39 @@ public class FactoryJeiPlugin implements IModPlugin {
 
 		List<IRecipeCategory> categories = new ArrayList<>();
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.BOTTLER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.BOTTLER)) {
 			categories.add(new BottlerRecipeCategory(guiHelper));
 		}
-		if(ModuleFactory.machineEnabled(MachineUIDs.CARPENTER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.CARPENTER)) {
 			categories.add(new CarpenterRecipeCategory(guiHelper));
 		}
-		if(ModuleFactory.machineEnabled(MachineUIDs.CENTRIFUGE)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.CENTRIFUGE)) {
 			categories.add(new CentrifugeRecipeCategory(guiHelper));
 		}
-		if(ModuleFactory.machineEnabled(MachineUIDs.FABRICATOR)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.FABRICATOR)) {
 			categories.add(new FabricatorRecipeCategory(guiHelper));
 		}
-		if(ModuleFactory.machineEnabled(MachineUIDs.FERMENTER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.FERMENTER)) {
 			categories.add(new FermenterRecipeCategory(guiHelper));
 		}
-		if(ModuleFactory.machineEnabled(MachineUIDs.MOISTENER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.MOISTENER)) {
 			categories.add(new MoistenerRecipeCategory(guiHelper));
 		}
-		if(ModuleFactory.machineEnabled(MachineUIDs.RAINMAKER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.RAINMAKER)) {
 			categories.add(new RainmakerRecipeCategory(guiHelper));
 		}
-		if(ModuleFactory.machineEnabled(MachineUIDs.SQUEEZER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.SQUEEZER)) {
 			categories.add(new SqueezerRecipeCategory(guiHelper));
 		}
-		if(ModuleFactory.machineEnabled(MachineUIDs.STILL)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.STILL)) {
 			categories.add(new StillRecipeCategory(guiHelper));
 		}
 
-		registry.addRecipeCategories(
-				categories.toArray(new IRecipeCategory[0])
-		);
+		if (!categories.isEmpty()) {
+			registry.addRecipeCategories(
+					categories.toArray(new IRecipeCategory[0])
+			);
+		}
 	}
 
 	@Override
@@ -126,67 +126,86 @@ public class FactoryJeiPlugin implements IModPlugin {
 
 		IRecipeTransferRegistry transferRegistry = registry.getRecipeTransferRegistry();
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.BOTTLER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.BOTTLER)) {
 			registry.addRecipes(BottlerRecipeMaker.getBottlerRecipes(registry.getIngredientRegistry()), ForestryRecipeCategoryUid.BOTTLER);
 			registry.addRecipeClickArea(GuiBottler.class, 107, 33, 26, 22, ForestryRecipeCategoryUid.BOTTLER);
 			registry.addRecipeClickArea(GuiBottler.class, 45, 33, 26, 22, ForestryRecipeCategoryUid.BOTTLER);
 			registry.addRecipeCatalyst(new ItemStack(blocks.bottler), ForestryRecipeCategoryUid.BOTTLER);
-
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.bottler));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.CARPENTER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.CARPENTER)) {
 			registry.addRecipes(CarpenterRecipeMaker.getCarpenterRecipes(), ForestryRecipeCategoryUid.CARPENTER);
 			registry.addRecipeClickArea(GuiCarpenter.class, 98, 48, 21, 26, ForestryRecipeCategoryUid.CARPENTER);
 			registry.addRecipeCatalyst(new ItemStack(blocks.carpenter), ForestryRecipeCategoryUid.CARPENTER);
 			transferRegistry.addRecipeTransferHandler(new CarpenterRecipeTransferHandler(), ForestryRecipeCategoryUid.CARPENTER);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.carpenter));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.CENTRIFUGE)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.CENTRIFUGE)) {
 			registry.addRecipes(CentrifugeRecipeMaker.getCentrifugeRecipe(), ForestryRecipeCategoryUid.CENTRIFUGE);
 			registry.addRecipeClickArea(GuiCentrifuge.class, 38, 22, 38, 14, ForestryRecipeCategoryUid.CENTRIFUGE);
 			registry.addRecipeClickArea(GuiCentrifuge.class, 38, 54, 38, 14, ForestryRecipeCategoryUid.CENTRIFUGE);
 			registry.addRecipeCatalyst(new ItemStack(blocks.centrifuge), ForestryRecipeCategoryUid.CENTRIFUGE);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.centrifuge));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.FABRICATOR)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.FABRICATOR)) {
 			registry.addRecipes(FabricatorRecipeMaker.getFabricatorRecipes(), ForestryRecipeCategoryUid.FABRICATOR);
 			registry.addRecipeClickArea(GuiFabricator.class, 121, 53, 18, 18, ForestryRecipeCategoryUid.FABRICATOR);
 			registry.addRecipeCatalyst(new ItemStack(blocks.fabricator), ForestryRecipeCategoryUid.FABRICATOR);
 			transferRegistry.addRecipeTransferHandler(new FabricatorRecipeTransferHandler(), ForestryRecipeCategoryUid.FABRICATOR);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.fabricator));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.FERMENTER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.FERMENTER)) {
 			registry.addRecipes(FermenterRecipeMaker.getFermenterRecipes(jeiHelpers.getStackHelper()), ForestryRecipeCategoryUid.FERMENTER);
 			registry.addRecipeClickArea(GuiFermenter.class, 72, 40, 32, 18, ForestryRecipeCategoryUid.FERMENTER);
 			registry.addRecipeCatalyst(new ItemStack(blocks.fermenter), ForestryRecipeCategoryUid.FERMENTER);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.fermenter));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.MOISTENER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.MOISTENER)) {
 			registry.addRecipes(MoistenerRecipeMaker.getMoistenerRecipes(), ForestryRecipeCategoryUid.MOISTENER);
 			registry.addRecipeClickArea(GuiMoistener.class, 123, 35, 19, 21, ForestryRecipeCategoryUid.MOISTENER);
 			registry.addRecipeCatalyst(new ItemStack(blocks.moistener), ForestryRecipeCategoryUid.MOISTENER);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.moistener));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.RAINMAKER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.RAINMAKER)) {
 			registry.addRecipes(RainmakerRecipeMaker.getRecipes(), ForestryRecipeCategoryUid.RAINMAKER);
 			registry.addRecipeCatalyst(new ItemStack(blocks.rainmaker), ForestryRecipeCategoryUid.RAINMAKER);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.rainmaker));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.SQUEEZER)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.SQUEEZER)) {
 			registry.addRecipes(SqueezerRecipeMaker.getSqueezerRecipes(), ForestryRecipeCategoryUid.SQUEEZER);
 			registry.addRecipes(SqueezerRecipeMaker.getSqueezerContainerRecipes(registry.getIngredientRegistry()), ForestryRecipeCategoryUid.SQUEEZER);
 			registry.addRecipeClickArea(GuiSqueezer.class, 76, 41, 43, 16, ForestryRecipeCategoryUid.SQUEEZER);
 			registry.addRecipeCatalyst(new ItemStack(blocks.squeezer), ForestryRecipeCategoryUid.SQUEEZER);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.squeezer));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.STILL)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.STILL)) {
 			registry.addRecipes(StillRecipeMaker.getStillRecipes(), ForestryRecipeCategoryUid.STILL);
 			registry.addRecipeClickArea(GuiStill.class, 73, 17, 33, 57, ForestryRecipeCategoryUid.STILL);
 			registry.addRecipeCatalyst(new ItemStack(blocks.still), ForestryRecipeCategoryUid.STILL);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.still));
 		}
 
-		if(ModuleFactory.machineEnabled(MachineUIDs.RAINTANK)) {
+		if (ModuleFactory.machineEnabled(MachineUIDs.RAINTANK)) {
 			JeiUtil.addDescription(registry, blocks.raintank);
+		} else {
+			jeiHelpers.getIngredientBlacklist().addIngredientToBlacklist(new ItemStack(blocks.raintank));
 		}
 
 	}

--- a/src/main/resources/assets/forestry/lang/en_us.lang
+++ b/src/main/resources/assets/forestry/lang/en_us.lang
@@ -1923,6 +1923,13 @@ for.config.power.types.tesla.comment=Enable Tesla power support.
 for.config.power.display.mode=Power Display Mode
 for.config.power.display.mode.comment=The format power will be displayed in in engine/machine interfaces.
 
+for.config.machines.enabled=Enabled machines.
+for.config.machines.enabled.comment=List of enabled machines. Note that some things may be impossible to do if you do this!
+for.config.machines.recipes_enabled=Enabled forestry recipes for machines.
+for.config.machines.recipes_enabled.comment=Enable forestry recipe maps for machines. Almost all of the time this should be the same as the list of enabled machines. %sIf you do disable machines removing from here will save some memory.
+
+
+
 ###################################
 # CUSTOM BEE AND TREE SPECIES NAMES
 ###################################

--- a/src/main/resources/assets/forestry/lang/en_us.lang
+++ b/src/main/resources/assets/forestry/lang/en_us.lang
@@ -1925,9 +1925,6 @@ for.config.power.display.mode.comment=The format power will be displayed in in e
 
 for.config.machines.enabled=Enabled machines.
 for.config.machines.enabled.comment=List of enabled machines. Note that some things may be impossible to do if you do this!
-for.config.machines.recipes_enabled=Enabled forestry recipes for machines.
-for.config.machines.recipes_enabled.comment=Enable forestry recipe maps for machines. Almost all of the time this should be the same as the list of enabled machines. %sIf you do disable machines removing from here will save some memory.
-
 
 
 ###################################

--- a/src/main/resources/assets/forestry/lang/en_us.lang
+++ b/src/main/resources/assets/forestry/lang/en_us.lang
@@ -1924,7 +1924,7 @@ for.config.power.display.mode=Power Display Mode
 for.config.power.display.mode.comment=The format power will be displayed in in engine/machine interfaces.
 
 for.config.machines.enabled=Enabled machines.
-for.config.machines.enabled.comment=List of enabled machines. Note that some things may be impossible to do if you do this!
+for.config.machines.enabled.comment=List of enabled machines. Note that some things may be impossible to do if you change this!
 
 
 ###################################


### PR DESCRIPTION
Closes https://github.com/ForestryMC/ForestryMC/issues/1973.

The changes seem very heavy but I'm not sure of a better way to add this in. Hopefully in 1.13 this could be rewritten to reduce the code needed.

There are 2 config options for each machine (aside from the bottler) since it's possible someone might use the forestry recipe map to create recipes for their machine. However, it's probably a bit overkill so I could remove it.