### PR TITLE
Check for IToolGrafter instead of ItemGrafter for non-Forestry leaves

### DIFF
--- a/src/main/java/forestry/arboriculture/ModuleArboriculture.java
+++ b/src/main/java/forestry/arboriculture/ModuleArboriculture.java
@@ -84,7 +84,7 @@ import forestry.arboriculture.genetics.TreeRoot;
 import forestry.arboriculture.genetics.TreekeepingMode;
 import forestry.arboriculture.genetics.alleles.AlleleFruits;
 import forestry.arboriculture.genetics.alleles.AlleleLeafEffects;
-import forestry.arboriculture.items.ItemGrafter;
+import forestry.api.arboriculture.IToolGrafter;
 import forestry.arboriculture.items.ItemRegistryArboriculture;
 import forestry.arboriculture.models.TextureLeaves;
 import forestry.arboriculture.models.WoodTextureManager;
@@ -612,7 +612,7 @@ public class ModuleArboriculture extends BlankForestryModule {
 			EntityPlayer player = event.getHarvester();
 			if (player != null) {
 				ItemStack harvestingTool = player.getHeldItemMainhand();
-				if (harvestingTool.getItem() instanceof ItemGrafter) {
+				if (harvestingTool.getItem() instanceof IToolGrafter) {
 					if (event.getDrops().isEmpty()) {
 						World world = event.getWorld();
 						Item itemDropped = block.getItemDropped(state, world.rand, 3);


### PR DESCRIPTION
There's currently a minor issue where items implementing `IToolGrafter` work for Forestry leaves, but not for vanilla or other mod leaves. This is because [AbstractLeaves checks for IToolGrafter](https://github.com/ForestryMC/ForestryMC/blob/mc-1.12/src/main/java/forestry/arboriculture/blocks/BlockAbstractLeaves.java#L179), while [ModuleArboriculture.onHarvestDropsEvent checks for ItemGrafter](https://github.com/ForestryMC/ForestryMC/blob/mc-1.12/src/main/java/forestry/arboriculture/ModuleArboriculture.java#L615).