### PR TITLE
more fixes for charcoal

### DIFF
--- a/src/main/java/forestry/arboriculture/blocks/BlockAsh.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockAsh.java
@@ -1,7 +1,5 @@
 package forestry.arboriculture.blocks;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 
 import net.minecraft.block.Block;
@@ -15,6 +13,7 @@ import net.minecraft.client.renderer.block.statemap.StateMap;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
@@ -47,7 +46,7 @@ public class BlockAsh extends Block implements IStateMapperRegister, IItemModelR
 	@SideOnly(Side.CLIENT)
 	@Override
 	public void registerModel(Item item, IModelManager manager) {
-		for(int i = 0;i < 16;i++){
+		for (int i = 0; i < 16; i++) {
 			manager.registerItemModel(item, i, "ash_block");
 		}
 	}
@@ -68,13 +67,14 @@ public class BlockAsh extends Block implements IStateMapperRegister, IItemModelR
 	}
 
 	@Override
-	public List<ItemStack> getDrops(IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
-		List<ItemStack> drops = new ArrayList<>();
-		Random rand = world instanceof World ? ((World)world).rand : new Random();
-		int amount = state.getValue(AMOUNT) + 9 + rand.nextInt(1 + fortune);
-		drops.add(new ItemStack(Items.COAL, amount, 1));
-		drops.add(new ItemStack(ModuleCore.getItems().ash, 1 + rand.nextInt(amount / 4)));
-		return drops;
+	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
+		Random rand = world instanceof World ? ((World) world).rand : new Random();
+		int amount = state.getValue(AMOUNT);
+		if (amount > 0) {
+			amount += rand.nextInt(1 + fortune);
+			drops.add(new ItemStack(Items.COAL, amount, 1));
+			drops.add(new ItemStack(ModuleCore.getItems().ash, 1 + rand.nextInt(amount / 4)));
+		}
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/forestry/arboriculture/blocks/BlockAsh.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockAsh.java
@@ -71,6 +71,7 @@ public class BlockAsh extends Block implements IStateMapperRegister, IItemModelR
 		Random rand = world instanceof World ? ((World) world).rand : new Random();
 		int amount = state.getValue(AMOUNT);
 		if (amount > 0) {
+			amount += 9;
 			amount += rand.nextInt(1 + fortune);
 			drops.add(new ItemStack(Items.COAL, amount, 1));
 			drops.add(new ItemStack(ModuleCore.getItems().ash, 1 + rand.nextInt(amount / 4)));

--- a/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
@@ -201,7 +201,11 @@ public class BlockWoodPile extends Block implements IItemModelRegister, IStateMa
 		for (EnumFacing facing : EnumFacing.VALUES) {
 			charcoalAmount += getCharcoalFaceAmount(world, pos, facing);
 		}
-		return charcoalAmount / 6;
+		float ret = charcoalAmount / 6;
+		if (ret > 0F) {
+			ret += 9F;    //base charcoal drop amount for ash block, calculated here instead so invalid walls son't still drop charcoal
+		}
+		return Math.min(ret, 15.0F);
 	}
 
 	private int getCharcoalFaceAmount(World world, BlockPos pos, EnumFacing facing) {
@@ -210,7 +214,7 @@ public class BlockWoodPile extends Block implements IItemModelRegister, IStateMa
 
 		BlockPos.MutableBlockPos testPos = new BlockPos.MutableBlockPos(pos);
 		testPos.move(facing);
-		while(!world.isAirBlock(testPos)) {
+		while (!world.isAirBlock(testPos)) {
 			testPos.move(facing);
 			IBlockState state = world.getBlockState(testPos);
 			for (ICharcoalPileWall wall : walls) {
@@ -219,7 +223,7 @@ public class BlockWoodPile extends Block implements IItemModelRegister, IStateMa
 				}
 			}
 		}
-		return 1;
+		return 0;
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
@@ -201,11 +201,7 @@ public class BlockWoodPile extends Block implements IItemModelRegister, IStateMa
 		for (EnumFacing facing : EnumFacing.VALUES) {
 			charcoalAmount += getCharcoalFaceAmount(world, pos, facing);
 		}
-		float ret = charcoalAmount / 6;
-		if (ret > 0F) {
-			ret += 9F;    //base charcoal drop amount for ash block, calculated here instead so invalid walls won't still drop charcoal
-		}
-		return Math.min(ret, 15.0F);
+		return Math.min(charcoalAmount / 6, 15.0F);
 	}
 
 	private int getCharcoalFaceAmount(World world, BlockPos pos, EnumFacing facing) {

--- a/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
@@ -203,7 +203,7 @@ public class BlockWoodPile extends Block implements IItemModelRegister, IStateMa
 		}
 		float ret = charcoalAmount / 6;
 		if (ret > 0F) {
-			ret += 9F;    //base charcoal drop amount for ash block, calculated here instead so invalid walls son't still drop charcoal
+			ret += 9F;    //base charcoal drop amount for ash block, calculated here instead so invalid walls won't still drop charcoal
 		}
 		return Math.min(ret, 15.0F);
 	}

--- a/src/main/java/forestry/arboriculture/charcoal/CharcoalPileWall.java
+++ b/src/main/java/forestry/arboriculture/charcoal/CharcoalPileWall.java
@@ -10,9 +10,12 @@
  ******************************************************************************/
 package forestry.arboriculture.charcoal;
 
+import com.google.common.base.Preconditions;
+
+import javax.annotation.Nullable;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 
@@ -20,27 +23,29 @@ import forestry.api.arboriculture.ICharcoalPileWall;
 
 public class CharcoalPileWall implements ICharcoalPileWall {
 
+	@Nullable
 	private final IBlockState blockState;
+	@Nullable
 	private final Block block;
 	private final int charcoalAmount;
-	
+
 	public CharcoalPileWall(IBlockState blockState, int charcoalAmount) {
 		this.blockState = blockState;
-		this.block = Blocks.AIR;
+		this.block = null;
 		this.charcoalAmount = charcoalAmount;
 	}
-	
+
 	public CharcoalPileWall(Block block, int charcoalAmount) {
-		this.blockState = Blocks.AIR.getDefaultState();
+		this.blockState = null;
 		this.block = block;
 		this.charcoalAmount = charcoalAmount;
 	}
-	
+
 	@Override
 	public int getCharcoalAmount() {
 		return charcoalAmount;
 	}
-	
+
 	@Override
 	public boolean matches(IBlockState state) {
 		return block == state.getBlock() || blockState == state;
@@ -48,12 +53,14 @@ public class CharcoalPileWall implements ICharcoalPileWall {
 
 	@Override
 	public NonNullList<ItemStack> getDisplayItems() {
-		if(block == Blocks.AIR){
+		if (block == null) {
+			Preconditions.checkNotNull(blockState);
 			return NonNullList.withSize(1, new ItemStack(blockState.getBlock(), 1, blockState.getBlock().getMetaFromState(blockState)));
-		}else if(blockState == Blocks.AIR.getDefaultState()){
+		} else if (blockState == null) {
+			Preconditions.checkNotNull(block);
 			return NonNullList.withSize(1, new ItemStack(block));
 		}
 		return NonNullList.create();
 	}
-	
+
 }


### PR DESCRIPTION
- use null instead of air blocks in CharcoalPileWall to prevent matching returning true for air blocks:
Caused a regression where charcoal pits with invalid walls would just match the first wall because air state would match with any walls registered with just a block.

- don't give any charcoal for blocks that aren't charcoal walls:
The old code (#2241 and before) gave at least 1 charcoal per face but I don't think this is balanced, since charcoal piles then just become a furnace for free that give ash too. Also updates `BlockAsh` to use the new `getDrops` method.
