### PR TITLE
prevent wood pile from loading more chunks

### DIFF
--- a/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
@@ -210,7 +210,7 @@ public class BlockWoodPile extends Block implements IItemModelRegister, IStateMa
 
 		BlockPos.MutableBlockPos testPos = new BlockPos.MutableBlockPos(pos);
 		testPos.move(facing);
-		while (!world.isAirBlock(testPos)) {
+		while (!world.isAirBlock(testPos) && world.isBlockLoaded(testPos)) {
 			testPos.move(facing);
 			IBlockState state = world.getBlockState(testPos);
 			for (ICharcoalPileWall wall : walls) {


### PR DESCRIPTION
I think this is the cause of https://github.com/ForestryMC/ForestryMC/issues/2264. In the stoneblock map there aren't any air blocks so a charcoal pit without a wall built next to the edge could continue scanning chunks forever. I thought this could occur when in https://github.com/ForestryMC/ForestryMC/pull/2241 but I couldn't get it to happen there.

Another solution would be to limit the maximum size of the charcoal pit.