### PR TITLE
prevent overflow of slots in database causing contents to be lost

### DIFF
--- a/src/main/java/forestry/core/utils/InventoryUtil.java
+++ b/src/main/java/forestry/core/utils/InventoryUtil.java
@@ -617,7 +617,8 @@ public abstract class InventoryUtil {
 
 	/**
 	 * The database has an inventory large enough that int must be used here instead of byte
-	 */
+	 * TODO in 1.13 - remove migrations from this.
+	 * */
 	public static void readFromNBT(IInventory inventory, NBTTagCompound nbttagcompound) {
 		if (!nbttagcompound.hasKey(inventory.getName())) {
 			return;
@@ -627,7 +628,13 @@ public abstract class InventoryUtil {
 
 		for (int j = 0; j < nbttaglist.tagCount(); ++j) {
 			NBTTagCompound nbttagcompound2 = nbttaglist.getCompoundTagAt(j);
-			int index = nbttagcompound2.getInteger("Slot");
+			int index;
+			//type of byte tag is 1
+			if(nbttagcompound2.hasKey("Slot", 1)) {
+				index = nbttagcompound2.getByte("Slot");
+			} else {
+				index = nbttagcompound2.getInteger("Slot");
+			}
 			inventory.setInventorySlotContents(index, new ItemStack(nbttagcompound2));
 		}
 	}

--- a/src/main/java/forestry/core/utils/InventoryUtil.java
+++ b/src/main/java/forestry/core/utils/InventoryUtil.java
@@ -614,6 +614,10 @@ public abstract class InventoryUtil {
 	}
 
 	/* NBT */
+
+	/**
+	 * The database has an inventory large enough that int must be used here instead of byte
+	 */
 	public static void readFromNBT(IInventory inventory, NBTTagCompound nbttagcompound) {
 		if (!nbttagcompound.hasKey(inventory.getName())) {
 			return;
@@ -623,7 +627,7 @@ public abstract class InventoryUtil {
 
 		for (int j = 0; j < nbttaglist.tagCount(); ++j) {
 			NBTTagCompound nbttagcompound2 = nbttaglist.getCompoundTagAt(j);
-			int index = nbttagcompound2.getByte("Slot");
+			int index = nbttagcompound2.getInteger("Slot");
 			inventory.setInventorySlotContents(index, new ItemStack(nbttagcompound2));
 		}
 	}
@@ -633,7 +637,7 @@ public abstract class InventoryUtil {
 		for (int i = 0; i < inventory.getSizeInventory(); i++) {
 			if (!inventory.getStackInSlot(i).isEmpty()) {
 				NBTTagCompound nbttagcompound2 = new NBTTagCompound();
-				nbttagcompound2.setByte("Slot", (byte) i);
+				nbttagcompound2.setInteger("Slot", i);
 				inventory.getStackInSlot(i).writeToNBT(nbttagcompound2);
 				nbttaglist.appendTag(nbttagcompound2);
 			}


### PR DESCRIPTION
Thanks @mconwa01 for finding the bug.

While doing this I also noticed there is a bug where the last slot of the database won't render the item in it. I tried changing this code down by 1 and the item would render but the slot would be in the wrong place: https://github.com/ForestryMC/ForestryMC/blob/7a45b02ca64b3bb952c2723e4f9868f3fcdda80d/src/main/java/forestry/database/gui/GuiDatabase.java#L147-L148

Presumably there is an off by 1 error somewhere for the rendering bug but I can't find it yet.