### PR TITLE
resolve gamemode recreate definitions

### DIFF
--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -214,26 +214,21 @@ public class Config {
 
 	private static void loadConfigCommon(Side side) {
 
-		gameMode = configCommon.getStringLocalized("difficulty", "game.mode", "EASY", new String[]{"OP, EASY, NORMAL, HARD"});
+		String[] gameModes = new String[]{"EASY", "NORMAL", "HARD", "OP"};
+		gameMode = configCommon.getStringLocalized("difficulty", "game.mode", "EASY", gameModes);
 
-		boolean recreate = configCommon.getBooleanLocalized("difficulty", "recreate.definitions", true);
+		boolean recreate = configCommon.getBooleanLocalized("difficulty", "recreate.definitions", false);
 		if (recreate) {
-			Log.info("Recreating all gamemode definitions from the defaults. This may be caused by an upgrade");
-
 			String recreateDefinitionsComment = Translator.translateToLocal("for.config.difficulty.recreate.definitions.comment");
 			Property property = configCommon.get("difficulty", "recreate.definitions", true, recreateDefinitionsComment);
 			property.set(false);
+		}
 
-			// Make sure the default mode files are there.
-
-			File opMode = new File(Forestry.instance.getConfigFolder(), "gamemodes/OP.cfg");
-			copyFileToFS(opMode, "/config/forestry/gamemodes/OP.cfg");
-
-			File normalMode = new File(Forestry.instance.getConfigFolder(), "gamemodes/NORMAL.cfg");
-			copyFileToFS(normalMode, "/config/forestry/gamemodes/NORMAL.cfg");
-
-			File hardMode = new File(Forestry.instance.getConfigFolder(), "gamemodes/HARD.cfg");
-			copyFileToFS(hardMode, "/config/forestry/gamemodes/HARD.cfg");
+		for (String gameMode : gameModes) {
+			File modeFile = new File(Forestry.instance.getConfigFolder(), String.format("gamemodes/%s.cfg", gameMode));
+			if (!modeFile.exists() || recreate) {
+				copyFileToFS(modeFile, String.format("/config/forestry/gamemodes/%s.cfg", gameMode));
+			}
 		}
 
 		// RetroGen

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -219,6 +219,7 @@ public class Config {
 
 		boolean recreate = configCommon.getBooleanLocalized("difficulty", "recreate.definitions", false);
 		if (recreate) {
+			Log.info("Recreating all gamemode definitions from the defaults. This may be caused by an upgrade");
 			String recreateDefinitionsComment = Translator.translateToLocal("for.config.difficulty.recreate.definitions.comment");
 			Property property = configCommon.get("difficulty", "recreate.definitions", true, recreateDefinitionsComment);
 			property.set(false);

--- a/src/main/resources/config/forestry/gamemodes/EASY.cfg
+++ b/src/main/resources/config/forestry/gamemodes/EASY.cfg
@@ -1,0 +1,144 @@
+# Configuration file
+
+~CONFIG_VERSION: 1.0.0
+
+gamemode {
+
+    energy {
+        # Modifies the energy required to activate machines, as well as the max amount of energy stored and accepted. [range: 0.0 ~ 10.0, default: 1.0]
+        S:demand.modifier=1.0
+
+        # Enable the clockwork engine. [default: true]
+        B:engine.clockwork=true
+    }
+
+    farms {
+        # for.config.gamemode.farms.fertilizer.modifier.comment [range: 0 ~ 2000, default: 4]
+        I:fertilizer.modifier=4
+    }
+
+    fuel {
+
+        ethanol {
+            # modifies the energy provided by ethanol in Buildcraft Combustion Engines. [range: 0.0 ~ 10.0, default: 1.0]
+            S:combustion=1.0
+
+            # modifies the energy provided by ethanol in a Bio Generator. [range: 0.0 ~ 10.0, default: 1.0]
+            S:generator=1.0
+        }
+
+        biomass {
+            # modifies the energy provided by Biomass in Biogas Engines. [range: 0.0 ~ 10.0, default: 1.0]
+            S:biogas=1.0
+
+            # modifies the energy provided by Biomass in a Bio Generator. [range: 0.0 ~ 10.0, default: 1.0]
+            S:generator=1.0
+        }
+
+    }
+
+    recipe {
+
+        output {
+            # amount yielded by the recipe for tin cans. [range: 0 ~ 2000, default: 12]
+            I:can=12
+
+            # amount yielded by the recipe for wax capsules. [range: 0 ~ 2000, default: 4]
+            I:capsule=4
+
+            # amount yielded by the recipe for refractory capsules. [range: 0 ~ 2000, default: 4]
+            I:refractory=4
+
+            fertilizer {
+                # amount of fertilizer yielded by the recipe using apatite. [range: 0 ~ 2000, default: 8]
+                I:apatite=8
+
+                # amount of fertilizer yielded by the recipe using ash. [range: 0 ~ 2000, default: 16]
+                I:ash=16
+            }
+
+            compost {
+                # amount of compost yielded by the recipe using ash. [range: 0 ~ 2000, default: 1]
+                I:ash=1
+
+                # amount of compost yielded by the recipe using wheat. [range: 0 ~ 2000, default: 4]
+                I:wheat=4
+            }
+
+            humus {
+                # amount of humus yielded by the recipe using compost. [range: 0 ~ 2000, default: 8]
+                I:compost=8
+
+                # amount of humus yielded by the recipe using fertilizer. [range: 0 ~ 2000, default: 8]
+                I:fertilizer=8
+            }
+
+            bogearth {
+                # amount of bog earth yielded by the recipe using buckets. [range: 0 ~ 2000, default: 6]
+                I:bucket=6
+
+                # amount of bog earth yielded by the recipes using cans, cells or capsules. [range: 0 ~ 2000, default: 8]
+                I:can=8
+            }
+
+        }
+
+    }
+
+    fermenter {
+
+        cycles {
+            # modifies the amount of cycles compost can keep a fermenter going. [range: 0 ~ 2000, default: 250]
+            I:compost=250
+
+            # modifies the amount of cycles fertilizer can keep a fermenter going. [range: 0 ~ 2000, default: 200]
+            I:fertilizer=200
+        }
+
+        value {
+            # modifies the amount of biomass per cycle a fermenter will produce using compost. [range: 0 ~ 2000, default: 48]
+            I:compost=48
+
+            # modifies the amount of biomass per cycle a fermenter will produce using fertilizer. [range: 0 ~ 2000, default: 56]
+            I:fertilizer=56
+        }
+
+        yield {
+            # modifies the amount of biomass a piece of cactus will yield in a fermenter. [range: 0 ~ 2000, default: 50]
+            I:cactus=50
+
+            # modifies the amount of biomass a piece of sugar cane will yield in a fermenter. [range: 0 ~ 2000, default: 50]
+            I:cane=50
+
+            # modifies the amount of biomass a mushroom will yield in a fermenter. [range: 0 ~ 2000, default: 50]
+            I:mushroom=50
+
+            # modifies the base amount of biomass a sapling will yield in a fermenter, affected by sappiness trait. [range: 0 ~ 2000, default: 250]
+            I:sapling=250
+
+            # modifies the amount of biomass a piece of wheat will yield in a fermenter. [range: 0 ~ 2000, default: 50]
+            I:wheat=50
+        }
+
+    }
+
+    squeezer {
+
+        liquid {
+            # modifies the amount of juice squeezed from a single apple. other sources are based off this. [range: 0 ~ 2000, default: 200]
+            I:apple=200
+
+            # modifies the amount of seed oil squeezed from a single seed. other sources are based off this. [range: 0 ~ 2000, default: 10]
+            I:seed=10
+        }
+
+        mulch {
+            # modifies the chance of mulch per squeezed apple. [range: 0 ~ 2000, default: 20]
+            I:apple=20
+        }
+
+    }
+
+}
+
+


### PR DESCRIPTION
- Make sure all gamemode files copied across when resetting (hopefully the EASY one I have copied to assets is correct)
- Copy gamemode files automatically if they don't exist.
- Set default of recreate.definitions to false