### PR TITLE
prevent crash for leaves where default can't be found

### DIFF
--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -79,7 +79,8 @@ import forestry.plugins.PluginTechReborn;
 		+ "after:" + PluginNatura.MOD_ID + ";"
 		+ "after:toughasnails;"
 		+ "after:" + PluginTechReborn.MOD_ID + ";"
-		+ "after:" + PluginBuildCraftFuels.MOD_ID + ";")
+		+ "after:" + PluginBuildCraftFuels.MOD_ID + ";"
+		+ "before:binniecore@[2.5.1.184,)")
 public class Forestry {
 
 	@SuppressWarnings("NullableProblems")

--- a/src/main/java/forestry/arboriculture/tiles/TileLeaves.java
+++ b/src/main/java/forestry/arboriculture/tiles/TileLeaves.java
@@ -145,10 +145,11 @@ public class TileLeaves extends TileTreeContainer implements IPollinatable, IFru
 
 		if (!checkedForConversionToDefaultLeaves) {
 			if (shouldConvertToDefaultLeaves()) {
-				IBlockState defaultLeaves;
+				IBlockState defaultLeaves = null;
 				if (isFruitLeaf) {
 					defaultLeaves = ModuleArboriculture.getBlocks().getDefaultLeavesFruit(primary.getUID());
-				} else {
+				}
+				if(defaultLeaves == null) {
 					defaultLeaves = ModuleArboriculture.getBlocks().getDefaultLeaves(primary.getUID());
 				}
 				worldIn.setBlockState(getPos(), defaultLeaves);
@@ -318,8 +319,8 @@ public class TileLeaves extends TileTreeContainer implements IPollinatable, IFru
 		if (individual instanceof ITree) {
 			ITree tree = getTree();
 			return tree != null &&
-				tree.getMate() == null &&
-				(ModuleApiculture.doSelfPollination || !tree.isGeneticEqual(individual));
+					tree.getMate() == null &&
+					(ModuleApiculture.doSelfPollination || !tree.isGeneticEqual(individual));
 		}
 		return false;
 	}


### PR DESCRIPTION
Stops the crash in #2323 but doesn't necessarily fix the underlying issue. Not sure what causes the crash so I've just added a logging diagnostic to hopefully work it out.