### PR TITLE
Fix updated buildcraft API name.

### DIFF
--- a/src/main/java/forestry/core/utils/InventoryUtil.java
+++ b/src/main/java/forestry/core/utils/InventoryUtil.java
@@ -86,7 +86,7 @@ public abstract class InventoryUtil {
 	}
 
 	//TODO Buildcraft for 1.9
-	@Optional.Method(modid = "BuildCraftAPI|transport")
+	@Optional.Method(modid = "buildcraftapi_transport")
 	private static boolean internal_moveOneItemToPipe(IItemHandler source, AdjacentTileCache tileCache, EnumFacing[] directions) {
 		//		IInventory invClone = new InventoryCopy(source);
 		//		ItemStack stackToMove = removeOneItem(invClone);


### PR DESCRIPTION
Caused by the fix for https://github.com/BuildCraft/BuildCraftAPI/issues/44 (where railcraft couldn't properly depend on the BC API's as forge rejected the old names).

This should fix #2340 and #2343.