### PR TITLE
fix charcoal amount calculation

### DIFF
--- a/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockWoodPile.java
@@ -20,6 +20,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
@@ -205,7 +206,7 @@ public class BlockWoodPile extends Block implements IItemModelRegister, IStateMa
 		for (EnumFacing facing : EnumFacing.VALUES) {
 			charcoalAmount += getCharcoalFaceAmount(world, pos, facing);
 		}
-		return Math.max(Math.min(charcoalAmount / 6, 63.0F - Config.charcoalAmountBase), -Config.charcoalAmountBase);
+		return MathHelper.clamp(charcoalAmount / 6, Config.charcoalAmountBase, 63.0F - Config.charcoalAmountBase);
 	}
 
 	private int getCharcoalFaceAmount(World world, BlockPos pos, EnumFacing facing) {


### PR DESCRIPTION
This could have been a 1 symbol fix to 
```Math.max(Math.min(charcoalAmount / 6, 63.0F - Config.charcoalAmountBase), Config.charcoalAmountBase);``` but I think rewriting a bit makes the code clearer.