### PR TITLE
Fix one resource leaking incident

### DIFF
--- a/src/main/java/forestry/core/utils/ModelUtil.java
+++ b/src/main/java/forestry/core/utils/ModelUtil.java
@@ -75,8 +75,8 @@ public class ModelUtil {
 	}
 
 	private static ItemCameraTransforms loadTransformFromJson(ResourceLocation location) {
-		try {
-			return ModelBlock.deserialize(getReaderForResource(location)).getAllTransforms();
+		try (Reader reader = getReaderForResource(location)) {
+			return ModelBlock.deserialize(reader).getAllTransforms();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Signed-off-by: liach <liach@users.noreply.github.com>

Example resource leaking: https://gist.github.com/ee2ffb7021d7fcf7928ba69e5cfbce99

Resouce leaks are only reported when debug level is turned on for the root logger, so you need to tweak log4j2 config in order to replicate it.

This would be a small favor to Railcraft development as Railcraft runs Forestry in the development environment. Thanks!