### PR TITLE
Fix #2336

### DIFF
--- a/src/main/java/forestry/arboriculture/blocks/BlockDefaultLeavesFruit.java
+++ b/src/main/java/forestry/arboriculture/blocks/BlockDefaultLeavesFruit.java
@@ -210,7 +210,7 @@ public abstract class BlockDefaultLeavesFruit extends BlockAbstractLeaves {
 	public void registerModel(Item item, IModelManager manager) {
 		for (IBlockState state : blockState.getValidStates()) {
 			int meta = getMetaFromState(state);
-			ModelLoader.setCustomModelResourceLocation(item, meta, new ModelResourceLocation("forestry:leaves.default." + blockNumber, "inventory"));
+			ModelLoader.setCustomModelResourceLocation(item, meta, new ModelResourceLocation("forestry:leaves.default.fruit." + blockNumber, "inventory"));
 		}
 	}
 


### PR DESCRIPTION
In `BlockDefaultLeavesFruit#registerModel`, the resource location started with `forestry:leaves.default.` rather than `forestry:leaves.default.fruit.`, causing the item to be rendered with `ModelDefaultLeaves` rather than `ModelDefaultLeavesFruit`, causing an assertion failure. This error was introduced in commit c1f8902c1664593da6425f556aa320fe90d45883, which corresponds to [build 367](http://jenkins.ic2.player.to/job/Forestry_1.11/367/).