### PR TITLE
fix check against null itemstack in electric engine

### DIFF
--- a/src/main/java/forestry/energy/tiles/TileEngineElectric.java
+++ b/src/main/java/forestry/energy/tiles/TileEngineElectric.java
@@ -180,7 +180,7 @@ public class TileEngineElectric extends TileEngine implements ISocketable, IInve
 			return;
 		}
 
-		if (getStackInSlot(InventoryEngineElectric.SLOT_BATTERY) != null) {
+		if (!getStackInSlot(InventoryEngineElectric.SLOT_BATTERY).isEmpty()) {
 			replenishFromBattery(InventoryEngineElectric.SLOT_BATTERY);
 		}
 


### PR DESCRIPTION
Surprised this wasn't caught earlier, but I guess people don't put batteries in their electric engines much.