### PR TITLE
fix runData crash and run data config

### DIFF
--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -19,19 +19,25 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.entity.EntityType;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.item.Item;
 import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.resources.IReloadableResourceManager;
+import net.minecraft.resources.IResourceManager;
 import net.minecraft.tileentity.TileEntityType;
 
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.ColorHandlerEvent;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 import net.minecraftforge.fml.DistExecutor;
@@ -68,6 +74,8 @@ import forestry.core.proxy.ProxyCommon;
 import forestry.core.proxy.ProxyRender;
 import forestry.core.proxy.ProxyRenderClient;
 import forestry.core.recipes.ModuleEnabledCondition;
+import forestry.core.render.ColourProperties;
+import forestry.core.render.TextureManagerForestry;
 import forestry.modules.ForestryModules;
 import forestry.modules.ModuleManager;
 //import forestry.plugins.ForestryCompatPlugins;
@@ -118,6 +126,7 @@ public class Forestry {
 		ClimateManager.climateFactory = ClimateFactory.INSTANCE;
 		ClimateManager.stateHelper = ClimateStateHelper.INSTANCE;
 		EnumErrorCode.init();
+
 		//TODO not sure where this is enabled any more
 		//		FluidRegistry.enableUniversalBucket();
 		ModuleManager moduleManager = ModuleManager.getInstance();
@@ -126,20 +135,21 @@ public class Forestry {
 		ModuleManager.runSetup();
 		NetworkHandler networkHandler = new NetworkHandler();
 		//				DistExecutor.runForDist(()->()-> networkHandler.clientPacketHandler(), ()->()-> networkHandler.serverPacketHandler());
-
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::setup);
+		IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
+		modEventBus.addListener(this::setup);
 		//		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::enqueueIMC);
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::processIMCMessages);
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::clientStuff);
-		FMLJavaModLoadingContext.get().getModEventBus().addListener(this::gatherData);
-		FMLJavaModLoadingContext.get().getModEventBus().register(TickHandlerCoreServer.class);    //TODO - correct?
+		modEventBus.addListener(this::processIMCMessages);
+		modEventBus.addListener(this::clientStuff);
+		modEventBus.addListener(this::gatherData);
+		modEventBus.register(TickHandlerCoreServer.class);    //TODO - correct?
 		EventHandlerCore eventHandlerCore = new EventHandlerCore();
-		FMLJavaModLoadingContext.get().getModEventBus().register(eventHandlerCore);
+		modEventBus.register(eventHandlerCore);
 		MinecraftForge.EVENT_BUS.register(this);
 		//TODO - I think this is how it works
 		Proxies.render = DistExecutor.runForDist(() -> () -> new ProxyRenderClient(), () -> () -> new ProxyRender());
 		Proxies.common = DistExecutor.runForDist(() -> () -> new ProxyClient(), () -> () -> new ProxyCommon());
 
+		DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> clientInit(modEventBus));
 		ModuleManager.getInternalHandler().runSetup();
 	}
 
@@ -191,6 +201,18 @@ public class Forestry {
 			}
 			//generator.run();
 		}
+	}
+
+	private void clientInit(IEventBus modEventBus) {
+		modEventBus.addListener(EventPriority.NORMAL, false, ColorHandlerEvent.Block.class, x -> {
+			Minecraft minecraft = Minecraft.getInstance();
+			IResourceManager resourceManager = minecraft.getResourceManager();
+			if(resourceManager instanceof IReloadableResourceManager) {
+				IReloadableResourceManager reloadableManager = (IReloadableResourceManager) resourceManager;
+				reloadableManager.addReloadListener(ColourProperties.INSTANCE);
+				reloadableManager.addReloadListener(TextureManagerForestry.getInstance());
+			}
+		});
 	}
 
 	@Mod.EventBusSubscriber(bus = Mod.EventBusSubscriber.Bus.MOD, modid = Constants.MOD_ID)

--- a/src/main/java/forestry/Forestry.java
+++ b/src/main/java/forestry/Forestry.java
@@ -197,7 +197,8 @@ public class Forestry {
 			generator.addProvider(new ForestryLootTableProvider(generator));
 			try {
 				generator.run();
-			} catch (Exception ignored) {
+			} catch (Exception e) {
+				LOGGER.error(e);
 			}
 			//generator.run();
 		}

--- a/src/main/java/forestry/core/ModuleCore.java
+++ b/src/main/java/forestry/core/ModuleCore.java
@@ -19,13 +19,11 @@ import java.util.List;
 import java.util.Set;
 
 import net.minecraft.block.Blocks;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScreenManager;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.resources.IReloadableResourceManager;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.storage.loot.functions.LootFunctionManager;
 
@@ -42,7 +40,6 @@ import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.fml.InterModComms;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.loading.FMLEnvironment;
 
 import forestry.api.circuits.ChipsetManager;
 import forestry.api.genetics.AlleleManager;
@@ -78,8 +75,6 @@ import forestry.core.owner.GameProfileDataSerializer;
 import forestry.core.proxy.Proxies;
 import forestry.core.recipes.HygroregulatorManager;
 import forestry.core.recipes.RecipeUtil;
-import forestry.core.render.ColourProperties;
-import forestry.core.render.TextureManagerForestry;
 import forestry.core.tiles.TileRegistryCore;
 import forestry.core.utils.ClimateUtil;
 import forestry.core.utils.ForestryModEnvWarningCallable;
@@ -158,12 +153,6 @@ public class ModuleCore extends BlankForestryModule {
 	@Override
 	public void registerBlocks() {
 		blocks = new BlockRegistryCore();
-
-		//TODO: Find better place for this, has to be loaded before setup
-		if (FMLEnvironment.dist == Dist.CLIENT) {
-			((IReloadableResourceManager) Minecraft.getInstance().getResourceManager()).addReloadListener(ColourProperties.INSTANCE);
-			((IReloadableResourceManager) Minecraft.getInstance().getResourceManager()).addReloadListener(TextureManagerForestry.getInstance());
-		}
 	}
 
 	@Override


### PR DESCRIPTION
The hacky event stuff was found in JEI

This could also be a useful tactic for avoiding registering genetics caps in the block registration event