### PR TITLE
try and debug network race condition some more, and prevent login crash

### DIFF
--- a/src/main/java/forestry/core/network/PacketHandler.java
+++ b/src/main/java/forestry/core/network/PacketHandler.java
@@ -73,8 +73,12 @@ public class PacketHandler {
 			threadListener.addScheduledTask(() -> {
 				try {
 					EntityPlayer player = Minecraft.getMinecraft().player;
-					Preconditions.checkNotNull(player, "Tried to send data to client before the player exists.");
-					packet.onPacketData(data, player);
+					if(player != null) {
+						packet.onPacketData(data, player);
+					} else {
+						Log.error("Client player was null when packet received: {}, {}", packet.getClass().getCanonicalName(), data.toString());
+						Log.error("Breeding trackers etc will likely be broken in this world");
+					}
 					data.release();
 				} catch (IOException e) {
 					Log.error("Network Error", e);


### PR DESCRIPTION
cc #2318 
Handling the packet outside the minecraft thread but relying on `Minecraft.player` to be set seems like a race condition, but I don't have a better solution right now. There are two other places using `PlayerLoggedInEvent` but run their code synchronously and things work fine for them.

I believe the race condition occurs when syncing breeding trackers, so perhaps sync lazily when required.

For now I think the best approach is to at least allow players to log in.