### PR TITLE
[1.12] fix arboretums getting saplings mixed up

### DIFF
--- a/src/main/java/forestry/api/farming/IFarmHousing.java
+++ b/src/main/java/forestry/api/farming/IFarmHousing.java
@@ -5,6 +5,7 @@
  ******************************************************************************/
 package forestry.api.farming;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
@@ -76,4 +77,8 @@ public interface IFarmHousing extends IErrorLogicSource {
 
 	/* GUI */
 	int getStoredFertilizerScaled(int scale);
+
+	default void addPendingProduce(ItemStack stack) {
+
+	}
 }

--- a/src/main/java/forestry/cultivation/tiles/TilePlanter.java
+++ b/src/main/java/forestry/cultivation/tiles/TilePlanter.java
@@ -534,4 +534,8 @@ public abstract class TilePlanter extends TilePowered implements IFarmHousing, I
 
 	public abstract NonNullList<ItemStack> createProductionStacks();
 
+	public void addPendingProduce(ItemStack stack) {
+		pendingProduce.push(stack);
+	}
+
 }

--- a/src/main/java/forestry/cultivation/tiles/TilePlanter.java
+++ b/src/main/java/forestry/cultivation/tiles/TilePlanter.java
@@ -534,6 +534,7 @@ public abstract class TilePlanter extends TilePowered implements IFarmHousing, I
 
 	public abstract NonNullList<ItemStack> createProductionStacks();
 
+	@Override
 	public void addPendingProduce(ItemStack stack) {
 		pendingProduce.push(stack);
 	}

--- a/src/main/java/forestry/farming/logic/FarmLogicArboreal.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicArboreal.java
@@ -73,9 +73,7 @@ public class FarmLogicArboreal extends FarmLogicHomogeneous {
 
 	@Override
 	public NonNullList<ItemStack> collect(World world, IFarmHousing farmHousing) {
-		NonNullList<ItemStack> products = produce;
-		produce = collectEntityItems(world, farmHousing, true);
-		return products;
+		return collectEntityItems(world, farmHousing, true);
 	}
 
 	private final Map<BlockPos, Integer> lastExtentsHarvest = new HashMap<>();

--- a/src/main/java/forestry/farming/logic/FarmLogicEnder.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicEnder.java
@@ -58,9 +58,7 @@ public class FarmLogicEnder extends FarmLogicHomogeneous {
 
 	@Override
 	public NonNullList<ItemStack> collect(World world, IFarmHousing farmHousing) {
-		NonNullList<ItemStack> products = produce;
-		produce = collectEntityItems(world, farmHousing, true);
-		return products;
+		return collectEntityItems(world, farmHousing, true);
 	}
 
 	private final Map<BlockPos, Integer> lastExtentsHarvest = new HashMap<>();

--- a/src/main/java/forestry/farming/logic/FarmLogicHomogeneous.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicHomogeneous.java
@@ -24,8 +24,6 @@ import forestry.api.farming.ISoil;
 import forestry.core.utils.BlockUtil;
 
 public abstract class FarmLogicHomogeneous extends FarmLogicSoil {
-	protected NonNullList<ItemStack> produce = NonNullList.create();
-
 	public FarmLogicHomogeneous(IFarmProperties properties, boolean isManual) {
 		super(properties, isManual);
 	}
@@ -94,7 +92,9 @@ public abstract class FarmLogicHomogeneous extends FarmLogicSoil {
 					break;
 				}
 
-				produce.addAll(BlockUtil.getBlockDrops(world, position));
+				for(ItemStack stack : BlockUtil.getBlockDrops(world, position)) {
+					farmHousing.addPendingProduce(stack);
+				}
 
 				BlockUtil.setBlockWithPlaceSound(world, position, soil.getSoilState());
 				farmHousing.getFarmInventory().removeResources(resources);

--- a/src/main/java/forestry/farming/logic/FarmLogicMushroom.java
+++ b/src/main/java/forestry/farming/logic/FarmLogicMushroom.java
@@ -46,9 +46,7 @@ public class FarmLogicMushroom extends FarmLogicArboreal {
 
 	@Override
 	public NonNullList<ItemStack> collect(World world, IFarmHousing farmHousing) {
-		NonNullList<ItemStack> products = produce;
-		produce = NonNullList.create();
-		return products;
+		return NonNullList.create();
 	}
 
 }

--- a/src/main/java/forestry/farming/logic/FarmProperties.java
+++ b/src/main/java/forestry/farming/logic/FarmProperties.java
@@ -30,9 +30,9 @@ public final class FarmProperties implements IFarmProperties {
 	private Collection<IFarmableInfo> farmableInfo;
 
 	public FarmProperties(BiFunction<IFarmProperties, Boolean, IFarmLogic> logicFactory, Set<String> farmablesIdentifiers, String identifier) {
-		this.farmablesIdentifiers = farmablesIdentifiers;
 		this.manualLogic = logicFactory.apply(this, true);
 		this.managedLogic = logicFactory.apply(this, false);
+		this.farmablesIdentifiers = farmablesIdentifiers;
 		this.defaultInfo = FarmRegistry.getInstance().getFarmableInfo(identifier);
 	}
 

--- a/src/main/java/forestry/farming/multiblock/FakeFarmController.java
+++ b/src/main/java/forestry/farming/multiblock/FakeFarmController.java
@@ -102,6 +102,11 @@ public class FakeFarmController extends FakeMultiblockController implements IFar
 	}
 
 	@Override
+	public void addPendingProduce(ItemStack stack) {
+
+	}
+
+	@Override
 	public int getSocketCount() {
 		return 0;
 	}

--- a/src/main/java/forestry/farming/multiblock/FarmController.java
+++ b/src/main/java/forestry/farming/multiblock/FarmController.java
@@ -601,6 +601,11 @@ public class FarmController extends RectangularMultiblockControllerBase implemen
 	}
 
 	@Override
+	public void addPendingProduce(ItemStack stack) {
+		pendingProduce.push(stack);
+	}
+
+	@Override
 	public boolean hasLiquid(FluidStack liquid) {
 		FluidStack drained = resourceTank.drainInternal(liquid, false);
 		return liquid.isFluidStackIdentical(drained);


### PR DESCRIPTION
I belive this is the simplest solution that makes sure farm logic is reused. I haven't tested with the multifarm yet though, but for single block farms this seems to work.