### PR TITLE
[1.12] fix unable to use wax cast

### DIFF
--- a/src/main/java/forestry/core/utils/ItemStackUtil.java
+++ b/src/main/java/forestry/core/utils/ItemStackUtil.java
@@ -58,6 +58,35 @@ public abstract class ItemStackUtil {
 		return ItemStack.areItemStackTagsEqual(lhs, rhs);
 	}
 
+	//TODO this is horrible and hopefully can be removed in 1.14, since it copy pastes a lot of vanilla code
+	public static boolean isIdenticalItemIgnoreCaps(ItemStack lhs, ItemStack rhs) {
+		if (lhs == rhs) {
+			return true;
+		}
+
+		if (lhs.isEmpty() || rhs.isEmpty()) {
+			return false;
+		}
+
+		if (lhs.getItem() != rhs.getItem()) {
+			return false;
+		}
+
+		if (lhs.getItemDamage() != OreDictionary.WILDCARD_VALUE) {
+			if (lhs.getItemDamage() != rhs.getItemDamage()) {
+				return false;
+			}
+		}
+
+
+		//copy of lower part of ItemStack::areItemStackTagsEqual without the caps check
+		if (lhs.getTagCompound() == null && rhs.getTagCompound() != null) {
+			return false;
+		} else {
+			return (lhs.getTagCompound() == null || lhs.getTagCompound().equals(rhs.getTagCompound()));
+		}
+	}
+
 
 	//TODO - move towards resourcelocations anyway as they are safer in some ways
 
@@ -491,6 +520,7 @@ public abstract class ItemStackUtil {
 	}
 
 	//TODO - just use a copy and set the count to make code simpler?
+
 	/**
 	 * Checks like {@link ItemStack#areItemStacksEqual(ItemStack, ItemStack)}
 	 * but ignores stack size (count).

--- a/src/main/java/forestry/factory/recipes/FabricatorRecipeManager.java
+++ b/src/main/java/forestry/factory/recipes/FabricatorRecipeManager.java
@@ -62,7 +62,7 @@ public class FabricatorRecipeManager implements IFabricatorManager {
 
 	public static boolean isPlan(ItemStack plan) {
 		for (IFabricatorRecipe recipe : recipes) {
-			if (ItemStackUtil.isIdenticalItem(recipe.getPlan(), plan)) {
+			if (ItemStackUtil.isIdenticalItemIgnoreCaps(recipe.getPlan(), plan)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
This is technically a breaking change but I don't think anyone was registering a fabricator plan recipe and then comparing cap NBT for it.

The fabricator checks for NBT tag equality on ingredients. Forge patches the usual method to also compare caps which is good in most cases. However, Astral Sorcery registers a cap on the wax cast when in world but not at the time it is created for the recipe. This means the NBT tags will never match.

The solution is to create a method to not check whether the caps are compatible on stacks.

fixes #2304 