### PR TITLE
Catch IllegalArgumentException on Ore ItemStacks

### DIFF
--- a/src/main/java/forestry/core/blocks/BlockResourceOre.java
+++ b/src/main/java/forestry/core/blocks/BlockResourceOre.java
@@ -122,8 +122,13 @@ public class BlockResourceOre extends Block implements IItemModelRegister, IBloc
 	}
 
 	@Override
-	public String getNameFromMeta(int meta) {
-		EnumResourceType resourceType = getStateFromMeta(meta).getValue(ORE_RESOURCES);
-		return resourceType.getName();
+	public String getNameFromMeta(final int meta) {
+    try {
+      final EnumResourceType resourceType = getStateFromMeta(meta).getValue(ORE_RESOURCES);
+		  return resourceType.getName();
+    } catch (final IllegalArgumentException ex) {
+      System.out.println("[Forestry] Erroneous PropertyEnum on ItemStack resource type.\nThis is a bug!");
+      return "invalid_itemstack_meta";
+    }
 	}
 }


### PR DESCRIPTION
Fixes #2515
Fixes #2505
Fixes #2502

This does not fix the underlying issue causing an invalid ORE_RESOURCES enumeration from being assigned. This can be sometimes replicated by using a Tinkers Construct pickaxe with Silktouch when mining Forestry resources. Dropped silktouch items are dropping invalid ItemStacks (they don't correspond to the block that was actually mined). Ore generation code should be reviewed for a possible fix to this error.
