### PR TITLE
EscritoireGameToken performance fix

### DIFF
--- a/src/main/java/forestry/core/tiles/EscritoireGameToken.java
+++ b/src/main/java/forestry/core/tiles/EscritoireGameToken.java
@@ -157,7 +157,7 @@ public class EscritoireGameToken implements INBTTagable, IStreamable {
 	@Override
 	public void writeData(DataOutputStreamForestry data) throws IOException {
 		data.writeEnum(state, State.VALUES);
-		data.writeItemStack(tokenStack);
+		data.writeItemStack(isVisible() ? tokenStack : null);
 	}
 
 	@Override


### PR DESCRIPTION
If the item of EscritoireGameToken is not visible then there is no need to send it