### PR TITLE
[1.12] Fix for #2541 - humus never turning to sand

### DIFF
--- a/src/main/java/forestry/core/blocks/BlockHumus.java
+++ b/src/main/java/forestry/core/blocks/BlockHumus.java
@@ -79,7 +79,7 @@ public class BlockHumus extends Block implements IItemModelRegister {
 
 	@Override
 	public void updateTick(World world, BlockPos pos, IBlockState state, Random rand) {
-		if (world.isRemote || world.rand.nextInt(140) != 0) {
+		if (world.isRemote || world.rand.nextInt(140) == 0) {
 			return;
 		}
 


### PR DESCRIPTION
This should allow humus to turn into sand again. In the current implementation, each time the humus block is ticked it returns immediately because there is rng that checks if said random number is zero. This effectively means that each tick only has a 1/141 chance of even checking if it is enrooted and thus advancing the degradation. Let me know if there is anything I overlooked or broke in this pr!