### PR TITLE
[1.12] Add config option to modify beehive light level - Issue #2237

### DIFF
--- a/src/main/java/forestry/apiculture/blocks/BlockBeeHives.java
+++ b/src/main/java/forestry/apiculture/blocks/BlockBeeHives.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import forestry.core.config.Config;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
@@ -51,10 +52,11 @@ import forestry.core.tiles.TileUtil;
 
 public class BlockBeeHives extends BlockContainer implements IItemModelRegister, IBlockWithMeta {
 	private static final PropertyEnum<HiveType> HIVE_TYPES = PropertyEnum.create("hive", HiveType.class);
+	private static final float LIGHT_LEVEL = Config.hiveLightLevel;
 
 	public BlockBeeHives() {
 		super(new MaterialBeehive(true));
-		setLightLevel(0.4f);
+		setLightLevel(LIGHT_LEVEL);
 		setHardness(2.5f);
 		setCreativeTab(Tabs.tabApiculture);
 		setHarvestLevel("scoop", 0);

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -61,6 +61,7 @@ public class Config {
 
 	// Graphics
 	public static boolean enableParticleFX = true;
+	public static float hiveLightLevel = 0.4F;
 
 	// Humus
 	public static int humusDegradeDelimiter = 3;
@@ -298,6 +299,7 @@ public class Config {
 			enableEnergyStat = configCommon.getBooleanLocalized("tweaks.gui.tabs", "energy", enableEnergyStat);
 
 			enableParticleFX = configCommon.getBooleanLocalized("performance", "particleFX", enableParticleFX);
+			hiveLightLevel = configCommon.getFloatLocalized("performance", "hiveLightLevel", hiveLightLevel, 0.0f, 0.4f);
 		}
 
 		farmSize = configCommon.getIntLocalized("tweaks.farms", "size", farmSize, 1, 3);

--- a/src/main/java/forestry/core/config/Config.java
+++ b/src/main/java/forestry/core/config/Config.java
@@ -299,7 +299,7 @@ public class Config {
 			enableEnergyStat = configCommon.getBooleanLocalized("tweaks.gui.tabs", "energy", enableEnergyStat);
 
 			enableParticleFX = configCommon.getBooleanLocalized("performance", "particleFX", enableParticleFX);
-			hiveLightLevel = configCommon.getFloatLocalized("performance", "hiveLightLevel", hiveLightLevel, 0.0f, 0.4f);
+			hiveLightLevel = configCommon.getFloatLocalized("performance", "hiveLightLevel", hiveLightLevel, 0.0f, 1.0f);
 		}
 
 		farmSize = configCommon.getIntLocalized("tweaks.farms", "size", farmSize, 1, 3);

--- a/src/main/resources/assets/forestry/lang/en_us.lang
+++ b/src/main/resources/assets/forestry/lang/en_us.lang
@@ -1669,6 +1669,7 @@ for.module.techreborn.description=Compatibility module for Tech reborn. Enables 
 for.config.performance=Performance
 for.config.performance.particleFX=Particle Effects
 for.config.performance.particleFX.comment=Enables particle effects. Note that Forestry respects Minecraft's reduced particle video settings.
+for.config.performance.hiveLightLevels=Sets the amount of light emitted by beehives.
 for.config.performance.backpacks.resupply=Backpack Resupply
 for.config.performance.backpacks.resupply.comment=Enable backpack resupply. You may want to set this to false on busy servers.
 

--- a/src/main/resources/assets/forestry/lang/en_us.lang
+++ b/src/main/resources/assets/forestry/lang/en_us.lang
@@ -1669,7 +1669,8 @@ for.module.techreborn.description=Compatibility module for Tech reborn. Enables 
 for.config.performance=Performance
 for.config.performance.particleFX=Particle Effects
 for.config.performance.particleFX.comment=Enables particle effects. Note that Forestry respects Minecraft's reduced particle video settings.
-for.config.performance.hiveLightLevels=Sets the amount of light emitted by beehives.
+for.config.performance.hiveLightLevels=Beehive Light Level
+for.config.performance.hiveLightLevels.comment=Sets the amount of light emitted by beehives.
 for.config.performance.backpacks.resupply=Backpack Resupply
 for.config.performance.backpacks.resupply.comment=Enable backpack resupply. You may want to set this to false on busy servers.
 


### PR DESCRIPTION
Added an option to common.cfg to change the amount of light beehives produce in a range from 0.0f (off) to 0.4f (the original value).