### PR TITLE
fix multiblocks not changing texture upon formation

### DIFF
--- a/src/main/java/forestry/apiculture/blocks/BlockAlveary.java
+++ b/src/main/java/forestry/apiculture/blocks/BlockAlveary.java
@@ -139,13 +139,10 @@ public class BlockAlveary extends BlockStructure {
 		return true;
 	}
 
-
-	@Override
-	public BlockState updatePostPlacement(BlockState state, Direction facing, BlockState facingState, IWorld world, BlockPos pos, BlockPos facingPos) {
-		TileAlveary tile = TileUtil.getTile(world, pos, TileAlveary.class);
-		if (tile == null) {
-			return super.updatePostPlacement(state, facing, facingState, world, pos, facingPos);
-		}
+	public BlockState getNewState(TileAlveary tile) {
+		BlockState state = this.getDefaultState();
+		World world = tile.getWorld();
+		BlockPos pos = tile.getPos();
 
 		if (tile instanceof IActivatable) {
 			if (((IActivatable) tile).isActive()) {
@@ -182,10 +179,8 @@ public class BlockAlveary extends BlockStructure {
 				}
 			}
 		}
-		RenderUtil.markForUpdate(pos);
-		return super.updatePostPlacement(state, facing, facingState, world, pos, facingPos);
+		return state;
 	}
-
 
 	private static List<Direction> getBlocksTouching(IBlockReader world, BlockPos blockPos) {
 		List<Direction> touching = new ArrayList<>();

--- a/src/main/java/forestry/apiculture/multiblock/TileAlveary.java
+++ b/src/main/java/forestry/apiculture/multiblock/TileAlveary.java
@@ -10,9 +10,11 @@
  ******************************************************************************/
 package forestry.apiculture.multiblock;
 
+import forestry.apiculture.blocks.BlockAlveary;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
+import net.minecraft.block.Block;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.container.Container;
@@ -66,28 +68,30 @@ public class TileAlveary extends MultiblockTileEntityForestry<MultiblockLogicAlv
 
 	@Override
 	public void onMachineAssembled(IMultiblockController multiblockController, BlockPos minCoord, BlockPos maxCoord) {
-		world.notifyNeighborsOfStateChange(getPos(), getBlockState().getBlock());//TODO check third bool, false);
+		Block block = getBlockState().getBlock();
+		if(block instanceof BlockAlveary) {
+			world.setBlockState(getPos(), ((BlockAlveary) block).getNewState(this));
+		}
+		world.notifyNeighborsOfStateChange(getPos(), block);
 		// Re-render this block on the client
 		if (world.isRemote) {
 			RenderUtil.markForUpdate(getPos());
 		}
 	}
 
-	//TODO refreshing
-	//	@Override
-	//	public boolean shouldRefresh(World world, BlockPos pos, BlockState oldState, BlockState newState) {
-	//		return oldState.getBlock() != newState.getBlock();
-	//	}
-
 	@Override
 	public void onMachineBroken() {
+		Block block = getBlockState().getBlock();
+		if(block instanceof BlockAlveary) {
+			world.setBlockState(getPos(), ((BlockAlveary) block).getNewState(this));
+		}
+		world.notifyNeighborsOfStateChange(getPos(), getBlockState().getBlock());
 		// Re-render this block on the client
 		if (world.isRemote) {
 			//TODO
 			BlockPos pos = getPos();
 			RenderUtil.markForUpdate(pos);
 		}
-		world.notifyNeighborsOfStateChange(getPos(), getBlockState().getBlock());//TODO 3rd bool, false);
 		markDirty();
 	}
 

--- a/src/main/java/forestry/farming/blocks/BlockFarm.java
+++ b/src/main/java/forestry/farming/blocks/BlockFarm.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.farming.blocks;
 
+import java.util.Locale;
 import javax.annotation.Nullable;
 
 import net.minecraft.block.Block;
@@ -17,8 +18,11 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.material.Material;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
+import net.minecraft.state.EnumProperty;
+import net.minecraft.state.StateContainer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
+import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
@@ -37,6 +41,17 @@ public class BlockFarm extends BlockStructure {
 	private final EnumFarmBlockType type;
 	private final EnumFarmMaterial farmMaterial;
 
+	public static final EnumProperty<State> STATE = EnumProperty.create("state", State.class);
+
+	public enum State implements IStringSerializable {
+		PLAIN, BAND;
+
+		@Override
+		public String getString() {
+			return name().toLowerCase(Locale.ENGLISH);
+		}
+	}
+
 	public BlockFarm(EnumFarmBlockType type, EnumFarmMaterial farmMaterial) {
 		super(Block.Properties.create(Material.ROCK)
 			.hardnessAndResistance(1.0f)
@@ -44,13 +59,17 @@ public class BlockFarm extends BlockStructure {
 			.harvestLevel(0));
 		this.type = type;
 		this.farmMaterial = farmMaterial;
+		setDefaultState(this.getStateContainer().getBaseState().with(STATE, State.PLAIN));
+	}
+
+	@Override
+	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
+		builder.add(STATE);
 	}
 
 	@Override
 	public void fillItemGroup(ItemGroup tab, NonNullList<ItemStack> list) {
-		if (type == EnumFarmBlockType.BAND) {
-			return;
-		}
 		super.fillItemGroup(tab, list);
 	}
 

--- a/src/main/java/forestry/farming/blocks/EnumFarmBlockType.java
+++ b/src/main/java/forestry/farming/blocks/EnumFarmBlockType.java
@@ -2,6 +2,7 @@ package forestry.farming.blocks;
 
 import com.google.common.collect.ImmutableList;
 
+import java.util.Arrays;
 import javax.annotation.Nullable;
 import java.util.Locale;
 
@@ -19,7 +20,6 @@ import forestry.core.utils.ResourceUtil;
 
 public enum EnumFarmBlockType implements IBlockSubtype {
 	PLAIN,
-	BAND,
 	GEARBOX,
 	HATCH,
 	VALVE,
@@ -84,8 +84,6 @@ public enum EnumFarmBlockType implements IBlockSubtype {
 				}
 				return sprites.get(TYPE_PLAIN);
 			}
-			case BAND:
-				return sprites.get(TYPE_BAND);
 			case GEARBOX:
 				return sprites.get(TYPE_GEARS);
 			case HATCH:
@@ -105,6 +103,14 @@ public enum EnumFarmBlockType implements IBlockSubtype {
 		for (int side = 0; side < textures.length; side++) {
 			textures[side] = getSprite(this, side);
 		}
+		return textures;
+	}
+
+	@OnlyIn(Dist.CLIENT)
+	public static TextureAtlasSprite[] getBandSprites() {
+		TextureAtlasSprite band = sprites == null ? ResourceUtil.getMissingTexture() : sprites.get(TYPE_BAND);
+		TextureAtlasSprite[] textures = new TextureAtlasSprite[6];
+		Arrays.fill(textures, band);
 		return textures;
 	}
 

--- a/src/main/java/forestry/farming/models/ModelFarmBlock.java
+++ b/src/main/java/forestry/farming/models/ModelFarmBlock.java
@@ -1,5 +1,6 @@
 package forestry.farming.models;
 
+import forestry.farming.blocks.BlockFarm.State;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -15,42 +16,49 @@ import forestry.farming.blocks.BlockFarm;
 import forestry.farming.blocks.EnumFarmBlockType;
 import forestry.farming.blocks.EnumFarmMaterial;
 import forestry.farming.features.FarmingBlocks;
+import org.apache.commons.lang3.tuple.Pair;
 
 @OnlyIn(Dist.CLIENT)
-public class ModelFarmBlock extends ModelBlockCached<BlockFarm, BlockFarm> {
+public class ModelFarmBlock extends ModelBlockCached<BlockFarm, Pair<BlockFarm, BlockFarm.State>> {
 
 	public ModelFarmBlock() {
 		super(BlockFarm.class);
 	}
 
 	@Override
-	protected BlockFarm getInventoryKey(ItemStack stack) {
+	protected Pair<BlockFarm, State> getInventoryKey(ItemStack stack) {
 		Block block = Block.getBlockFromItem(stack.getItem());
 		if (block instanceof BlockFarm) {
-			return ((BlockFarm) block);
+			return Pair.of((BlockFarm) block, State.PLAIN);
 		}
-		return FarmingBlocks.FARM.get(EnumFarmBlockType.PLAIN, EnumFarmMaterial.BRICK).block();
+		return Pair.of(FarmingBlocks.FARM.get(EnumFarmBlockType.PLAIN, EnumFarmMaterial.BRICK).block(), State.PLAIN);
 	}
 
 	@Override
-	protected BlockFarm getWorldKey(BlockState state, IModelData extraData) {
+	protected Pair<BlockFarm, State> getWorldKey(BlockState state, IModelData extraData) {
 		Block block = state.getBlock();
 		if (block instanceof BlockFarm) {
-			return ((BlockFarm) block);
+			return Pair.of((BlockFarm) block, state.get(BlockFarm.STATE));
 		}
-		return FarmingBlocks.FARM.get(EnumFarmBlockType.PLAIN, EnumFarmMaterial.BRICK).block();
+		return Pair.of(FarmingBlocks.FARM.get(EnumFarmBlockType.PLAIN, EnumFarmMaterial.BRICK).block(), State.PLAIN);
 	}
 
 	@Override
-	protected void bakeBlock(BlockFarm blockFarm, IModelData extraData, BlockFarm key, ModelBaker baker, boolean inventory) {
-		EnumFarmBlockType type = key.getType();
-		EnumFarmMaterial material = key.getFarmMaterial();
+	protected void bakeBlock(BlockFarm blockFarm, IModelData extraData, Pair<BlockFarm, State> key, ModelBaker baker, boolean inventory) {
+		EnumFarmBlockType type = key.getLeft().getType();
+		EnumFarmMaterial material = key.getLeft().getFarmMaterial();
 		TextureAtlasSprite[] textures = material.getSprites();
 
 		// Add the plain block.
 		baker.addBlockModel(textures, 0);
+
 		// Add the overlay block.
 		baker.addBlockModel(type.getSprites(), 0);
+
+		//Add band if plain block, since this is the only farm block type that can be used on layer 2
+		if(type == EnumFarmBlockType.PLAIN && key.getRight() == State.BAND) {
+			baker.addBlockModel(EnumFarmBlockType.getBandSprites(), 0);
+		}
 
 		// Set the particle sprite
 		baker.setParticleSprite(textures[0]);

--- a/src/main/java/forestry/farming/tiles/TileFarmPlain.java
+++ b/src/main/java/forestry/farming/tiles/TileFarmPlain.java
@@ -10,7 +10,11 @@
  ******************************************************************************/
 package forestry.farming.tiles;
 
+import forestry.farming.blocks.BlockFarm.State;
+import forestry.farming.blocks.EnumFarmBlockType;
+import forestry.farming.features.FarmingBlocks;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
 import net.minecraft.util.math.BlockPos;
 
 import forestry.api.multiblock.IMultiblockController;
@@ -18,7 +22,6 @@ import forestry.farming.blocks.BlockFarm;
 import forestry.farming.blocks.EnumFarmMaterial;
 import forestry.farming.features.FarmingTiles;
 
-//TODO: Fix band: currently breaks multiblocks because removes the old tile and adds a new tile, this causes a ConcurrentModificationException (attachBlock, detachBlock)
 public class TileFarmPlain extends TileFarm {
 	public TileFarmPlain() {
 		super(FarmingTiles.PLAIN.tileType());
@@ -32,11 +35,12 @@ public class TileFarmPlain extends TileFarm {
 		int bandY = maxCoord.getY() - 1;
 		if (getPos().getY() == bandY) {
 			EnumFarmMaterial material = EnumFarmMaterial.BRICK_STONE;
-			Block block = getBlockState().getBlock();
+			BlockState state = getBlockState();
+			Block block = state.getBlock();
 			if (block instanceof BlockFarm) {
 				material = ((BlockFarm) block).getFarmMaterial();
 			}
-			//this.world.setBlockState(getPos(), FarmingBlocks.FARM.get(EnumFarmBlockType.BAND, material).defaultState(), 2);
+			this.world.setBlockState(getPos(), state.with(BlockFarm.STATE, BlockFarm.State.BAND), 2);
 		}
 	}
 
@@ -46,10 +50,11 @@ public class TileFarmPlain extends TileFarm {
 
 		// set band block meta back to normal
 		EnumFarmMaterial material = EnumFarmMaterial.BRICK_STONE;
-		Block block = getBlockState().getBlock();
+		BlockState state = getBlockState();
+		Block block = state.getBlock();
 		if (block instanceof BlockFarm) {
 			material = ((BlockFarm) block).getFarmMaterial();
 		}
-		//this.world.setBlockState(getPos(), FarmingBlocks.FARM.get(EnumFarmBlockType.PLAIN, material).defaultState(), 2);
+		this.world.setBlockState(getPos(), state.with(BlockFarm.STATE, State.PLAIN), 2);
 	}
 }


### PR DESCRIPTION
When porting from 1.12 I couldn't get these to work properly, hopefully this fixes this. I moved the band to be part of blockstate since it only affects rendering. If we wanted this might allow us to use any kind of block for the band layer of the multifarm (gearbox, control, etc.)