### PR TITLE
Use Github Actions to produce snapshot builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+on:
+  - pull_request
+  - push
+
+jobs:
+  build:
+    if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Build
+        run: ./gradlew build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Forestry
+          path: build/libs/


### PR DESCRIPTION
Should convince more people to play-test since it's more accessible than the Jenkins. However, downloading artifacts requires you to be logged in iirc, but that shouldn't be much of an issue as if you're downloading snapshot builds you probably want to report bugs anyway