### PR TITLE
Better automated publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -16,10 +16,24 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
-      - name: Generate data
-        run: ./gradlew runData
+      - name: Use Gradle cache for faster builds
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties
+      - name: Setup Gradle Wrapper Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
       - name: Build
-        run: ./gradlew build
+        run: ./gradlew downloadAssets runData build
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,13 @@
 name: Publish
 
 on:
-  push:
-    branches:
-      - 'dev/**'
+  release:
+    types:
+      - published
 
 jobs:
   publish:
-    if: "! contains(toJSON(github.event.commits.*.message), '[ci skip]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -18,31 +17,30 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
-      # Generate a build number unique to the branch
-      - name: Generate build number
-        uses: einaregilsson/build-number@v3
-        with:
-          token: ${{ secrets.github_token }}
-          prefix: ${{ github.ref }}
-      - name: Generate data
-        run: ./gradlew runData
+      - name: Find Minecraft version
+        id: version
+        run: |
+          grep 'minecraft_version' gradle.properties > /tmp/minecraft_version
+          source /tmp/minecraft_version
+          echo ::set-output name=MINECRAFT_VERSION::$minecraft_version
       - name: Build
-        run: ./gradlew build
-      - name: Publish to Maven
-        if: "! contains(toJSON(github.event.commits.*.message), '[maven skip]')"
-        run: ./gradlew publishAllPublicationsToModmavenRepository
+        run: ./gradlew downloadAssets runData build
         env:
+          FORESTRY_VERSION: ${{ github.event.release.tag_name }}
+      - name: Upload Release Artifact
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./build/libs/forestry-${{ steps.version.outputs.MINECRAFT_VERSION }}-${{ github.event.release.tag_name }}.jar
+          asset_name: forestry-${{ steps.version.outputs.MINECRAFT_VERSION }}-${{ github.event.release.tag_name }}.jar
+          asset_content_type: application/zip
+      - name: Upload to external sites
+        run: ./gradlew publishAllPublicationsToModmavenRepository curseforge publishModrinth
+        env:
+          FORESTRY_VERSION: ${{ github.event.release.tag_name }}
           MODMAVEN_USER: ${{ secrets.MODMAVEN_USER }}
           MODMAVEN_PASSWORD: ${{ secrets.MODMAVEN_PASSWORD }}
-      - name: Upload to CurseForge
-        if: "! contains(toJSON(github.event.commits.*.message), '[curseforge skip]')"
-        run: ./gradlew curseforge
-        env:
-          CHANGELOG: ${{ github.event.head_commit.message }}
           CURSEFORGE: ${{ secrets.CURSEFORGE }}
-      - name: Upload to Modrinth
-        if: "! contains(toJSON(github.event.commits.*.message), '[modrinth skip]')"
-        run: ./gradlew publishModrinth
-        env:
-          CHANGELOG: ${{ github.event.head_commit.message }}
           MODRINTH: ${{ secrets.MODRINTH }}

--- a/build.gradle
+++ b/build.gradle
@@ -18,12 +18,8 @@ plugins {
 apply plugin: "net.minecraftforge.gradle"
 
 group = "net.sengir.forestry"
-version = computeVersion()
+version = System.getenv("FORESTRY_VERSION") ?: "0.0.0.0"
 archivesBaseName = "forestry-$minecraft_version"
-
-String computeVersion() {
-	return "$version_major.$version_minor.${System.getenv("BUILD_NUMBER") ?: "999+local"}"
-}
 
 repositories {
 	maven {
@@ -217,10 +213,8 @@ publishing {
 	}
 }
 
-def theChangelog = System.getenv("CHANGELOG")
-
 ////////////////
-// Curse Forge
+// CurseForge
 if (System.getenv("CURSEFORGE")) {
 	curseforge {
 		apiKey = System.getenv("CURSEFORGE")
@@ -228,8 +222,16 @@ if (System.getenv("CURSEFORGE")) {
 		project {
 			id = project.curseforge_project
 			changelogType = "markdown"
-			changelog = theChangelog
-			releaseType = theChangelog.contains("[beta]") ? "beta" : "alpha"
+			changelog = "View changelog at [the release page](https://github.com/ForestryMC/ForestryMC/releases/tag/${version})"
+
+			if (version.contains("alpha")) {
+				releaseType = "alpha"
+			} else if (version.contains("beta")) {
+				releaseType = "beta"
+			} else {
+				releaseType = "release"
+			}
+
 			addGameVersion project.minecraft_version
 			addGameVersion "Forge"
 
@@ -254,15 +256,23 @@ task publishModrinth(type: TaskModrinthUpload) {
 		System.getenv("MODRINTH")
 	}
 
+	dependsOn jar
+
 	token = System.getenv("MODRINTH")
-	changelog = theChangelog
+	changelog = "View changelog at [the release page](https://github.com/ForestryMC/ForestryMC/releases/tag/${version})"
 	projectId = project.modrinth_project
 	versionName = project.version
 	versionNumber = project.version
-	versionType = theChangelog?.contains("[beta]") ? VersionType.BETA : VersionType.ALPHA
+
+	if (version.contains("alpha")) {
+		versionType = VersionType.ALPHA
+	} else if (version.contains("beta")) {
+		versionType = VersionType.BETA
+	} else {
+		versionType = VersionType.RELEASE
+	}
+
 	uploadFile = jar
 	addGameVersion(project.minecraft_version)
 	addLoader("forge")
 }
-
-publishModrinth.dependsOn jar

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,5 @@ jei_version_range=[9.5.0,)
 patchouli_version=1.18.2-66
 patchouli_version_range=[1.16.4-53,)
 
-version_major=6
-version_minor=1
-
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xmx3G


### PR DESCRIPTION
* Uses a cache for commit builds, should make them only last a few minutes each
* Trigger release builds through a GitHub release, rather than commits to the `dev/xxx` branch