### PR TITLE
Update (re-add) tile-entity/item renderer for 1.18

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/forestry/apiculture/genetics/BeeDisplayHandler.java
+++ b/src/main/java/forestry/apiculture/genetics/BeeDisplayHandler.java
@@ -122,7 +122,8 @@ public enum BeeDisplayHandler implements IAlleleDisplayHandler<IBee> {
 	NEVER_SLEEPS(BeeChromosomes.NEVER_SLEEPS, -1, 5) {
 		@Override
 		public void addTooltip(ToolTip toolTip, IGenome genome, IBee individual) {
-			if (getActiveValue(genome)) {
+			Boolean value = getActiveValue(genome);
+			if (value) {
 				toolTip.text(GenericRatings.rateActivityTime(true, false)).style(ChatFormatting.RED);
 			}
 		}
@@ -130,7 +131,8 @@ public enum BeeDisplayHandler implements IAlleleDisplayHandler<IBee> {
 	TOLERATES_RAIN(BeeChromosomes.TOLERATES_RAIN, -1, 6) {
 		@Override
 		public void addTooltip(ToolTip toolTip, IGenome genome, IBee individual) {
-			if (getActiveValue(genome)) {
+			Boolean value = getActiveValue(genome);
+			if (value) {
 				toolTip.translated("for.gui.flyer.tooltip").style(ChatFormatting.WHITE);
 			}
 		}

--- a/src/main/java/forestry/core/blocks/IBlockTypeTesr.java
+++ b/src/main/java/forestry/core/blocks/IBlockTypeTesr.java
@@ -1,6 +1,26 @@
 package forestry.core.blocks;
 
+import forestry.core.render.RenderForestryItem;
+import net.minecraft.client.Minecraft;
+
 public interface IBlockTypeTesr extends IBlockType {
 	@Override
 	IMachinePropertiesTesr<?> getMachineProperties();
+	
+	default RenderForestryItem initRenderItem() {
+		IMachineProperties<?> machineProperties = this.getMachineProperties();
+		if (!(machineProperties instanceof IMachinePropertiesTesr<?> machinePropertiesTesr)) {
+			return null;
+		}
+		if (machinePropertiesTesr.getRenderer() == null) {
+			return null;
+		}
+		if (machinePropertiesTesr.getModelLayer() == null) {
+			return null;
+		}
+		return new RenderForestryItem(Minecraft.getInstance().getBlockEntityRenderDispatcher(),
+				Minecraft.getInstance().getEntityModels(), 
+				machinePropertiesTesr.getModelLayer(), 
+				machinePropertiesTesr.getRenderer());	
+	}
 }

--- a/src/main/java/forestry/core/blocks/IMachinePropertiesTesr.java
+++ b/src/main/java/forestry/core/blocks/IMachinePropertiesTesr.java
@@ -13,7 +13,6 @@ package forestry.core.blocks;
 import javax.annotation.Nullable;
 
 import net.minecraft.resources.ResourceLocation;
-
 import forestry.core.render.IForestryRendererProvider;
 import forestry.core.tiles.TileForestry;
 

--- a/src/main/java/forestry/core/blocks/IMachinePropertiesTesr.java
+++ b/src/main/java/forestry/core/blocks/IMachinePropertiesTesr.java
@@ -12,6 +12,7 @@ package forestry.core.blocks;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.resources.ResourceLocation;
 import forestry.core.render.IForestryRendererProvider;
 import forestry.core.tiles.TileForestry;
@@ -21,4 +22,7 @@ public interface IMachinePropertiesTesr<T extends TileForestry> extends IMachine
 
 	@Nullable
 	IForestryRendererProvider<? super T> getRenderer();
+	
+	@Nullable
+	ModelLayerLocation getModelLayer();
 }

--- a/src/main/java/forestry/core/blocks/IMachinePropertiesTesr.java
+++ b/src/main/java/forestry/core/blocks/IMachinePropertiesTesr.java
@@ -14,12 +14,12 @@ import javax.annotation.Nullable;
 
 import net.minecraft.resources.ResourceLocation;
 
-import forestry.core.render.IForestryRenderer;
+import forestry.core.render.IForestryRendererProvider;
 import forestry.core.tiles.TileForestry;
 
 public interface IMachinePropertiesTesr<T extends TileForestry> extends IMachineProperties<T> {
 	ResourceLocation getParticleTexture();
 
 	@Nullable
-	IForestryRenderer<? super T> getRenderer();
+	IForestryRendererProvider<? super T> getRenderer();
 }

--- a/src/main/java/forestry/core/blocks/MachinePropertiesTesr.java
+++ b/src/main/java/forestry/core/blocks/MachinePropertiesTesr.java
@@ -7,7 +7,6 @@ import java.util.function.Supplier;
 
 import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.state.BlockState;
 
 import net.minecraftforge.api.distmarker.Dist;
@@ -15,7 +14,6 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 
 import forestry.core.config.Constants;
-import forestry.core.proxy.Proxies;
 import forestry.core.render.IForestryRendererProvider;
 import forestry.core.render.RenderForestryTile;
 import forestry.core.tiles.TileForestry;
@@ -68,10 +66,10 @@ public class MachinePropertiesTesr<T extends TileForestry> extends MachineProper
 	public boolean isFullCube(BlockState state) {
 		return isFullCube;
 	}
-
-	public static Item.Properties setRenderer(Item.Properties properties, IBlockType type) {
-		Proxies.render.setRenderer(properties, type);
-		return properties;
+	
+	@Override
+	public ModelLayerLocation getModelLayer() {
+		return modelLayer;
 	}
 
 	public static class Builder<T extends TileForestry> extends MachineProperties.Builder<T, Builder<T>> {

--- a/src/main/java/forestry/core/blocks/MachinePropertiesTesr.java
+++ b/src/main/java/forestry/core/blocks/MachinePropertiesTesr.java
@@ -15,7 +15,7 @@ import net.minecraftforge.client.event.EntityRenderersEvent;
 
 import forestry.core.config.Constants;
 import forestry.core.proxy.Proxies;
-import forestry.core.render.IForestryRenderer;
+import forestry.core.render.IForestryRendererProvider;
 import forestry.core.render.RenderForestryTile;
 import forestry.core.tiles.TileForestry;
 import forestry.modules.features.FeatureTileType;
@@ -27,7 +27,7 @@ public class MachinePropertiesTesr<T extends TileForestry> extends MachineProper
 
 	@Nullable
 	@OnlyIn(Dist.CLIENT)
-	private IForestryRenderer<? super T> renderer;
+	private IForestryRendererProvider<? super T> renderer;
 
 	public MachinePropertiesTesr(Supplier<FeatureTileType<? extends T>> teType, String name, IShapeProvider shape, ResourceLocation particleTexture, boolean isFullCube) {
 		super(teType, name, shape);
@@ -36,13 +36,13 @@ public class MachinePropertiesTesr<T extends TileForestry> extends MachineProper
 	}
 
 	@OnlyIn(Dist.CLIENT)
-	public void setRenderer(IForestryRenderer<? super T> renderer) {
+	public void setRenderer(IForestryRendererProvider<? super T> renderer) {
 		this.renderer = renderer;
 	}
 
 	@Override
 	@Nullable
-	public IForestryRenderer<? super T> getRenderer() {
+	public IForestryRendererProvider<? super T> getRenderer() {
 		return renderer;
 	}
 
@@ -50,7 +50,7 @@ public class MachinePropertiesTesr<T extends TileForestry> extends MachineProper
 	@OnlyIn(Dist.CLIENT)
 	public void clientSetupRenderers(EntityRenderersEvent.RegisterRenderers event) {
 		if (renderer != null) {
-			event.registerBlockEntityRenderer(getTeType(), (context) -> new RenderForestryTile<>(renderer));
+			event.registerBlockEntityRenderer(getTeType(), (ctx) -> new RenderForestryTile<>(renderer.create(ctx)));
 		}
 	}
 

--- a/src/main/java/forestry/core/blocks/MachinePropertiesTesr.java
+++ b/src/main/java/forestry/core/blocks/MachinePropertiesTesr.java
@@ -5,6 +5,7 @@ import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 import java.util.function.Supplier;
 
+import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.state.BlockState;
@@ -27,6 +28,10 @@ public class MachinePropertiesTesr<T extends TileForestry> extends MachineProper
 
 	@Nullable
 	@OnlyIn(Dist.CLIENT)
+	private ModelLayerLocation modelLayer;
+	
+	@Nullable
+	@OnlyIn(Dist.CLIENT)
 	private IForestryRendererProvider<? super T> renderer;
 
 	public MachinePropertiesTesr(Supplier<FeatureTileType<? extends T>> teType, String name, IShapeProvider shape, ResourceLocation particleTexture, boolean isFullCube) {
@@ -36,7 +41,8 @@ public class MachinePropertiesTesr<T extends TileForestry> extends MachineProper
 	}
 
 	@OnlyIn(Dist.CLIENT)
-	public void setRenderer(IForestryRendererProvider<? super T> renderer) {
+	public void setRenderer(ModelLayerLocation modelLayer, IForestryRendererProvider<? super T> renderer) {
+		this.modelLayer = modelLayer;
 		this.renderer = renderer;
 	}
 
@@ -50,7 +56,7 @@ public class MachinePropertiesTesr<T extends TileForestry> extends MachineProper
 	@OnlyIn(Dist.CLIENT)
 	public void clientSetupRenderers(EntityRenderersEvent.RegisterRenderers event) {
 		if (renderer != null) {
-			event.registerBlockEntityRenderer(getTeType(), (ctx) -> new RenderForestryTile<>(renderer.create(ctx)));
+			event.registerBlockEntityRenderer(getTeType(), (ctx) -> new RenderForestryTile<>(renderer.create(ctx.bakeLayer(modelLayer))));
 		}
 	}
 

--- a/src/main/java/forestry/core/items/ItemBlockBase.java
+++ b/src/main/java/forestry/core/items/ItemBlockBase.java
@@ -1,21 +1,30 @@
 package forestry.core.items;
 
-import net.minecraft.world.level.block.Block;
+import java.util.function.Consumer;
 
 import forestry.core.ItemGroupForestry;
 import forestry.core.blocks.IBlockTypeTesr;
-import forestry.core.blocks.MachinePropertiesTesr;
-
-import net.minecraft.world.item.Item.Properties;
+import forestry.core.render.RenderForestryItemProperties;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.client.IItemRenderProperties;
 
 public class ItemBlockBase<B extends Block> extends ItemBlockForestry<B> {
-
-	public ItemBlockBase(B block, Properties builder, IBlockTypeTesr type) {
-		super(block, MachinePropertiesTesr.setRenderer(builder, type));
+	public final IBlockTypeTesr blockTypeTesr;
+	
+	public ItemBlockBase(B block, Properties builder, final IBlockTypeTesr blockTypeTesr) {
+		super(block, builder);
+		this.blockTypeTesr = blockTypeTesr;
 	}
 
-	public ItemBlockBase(B block, IBlockTypeTesr type) {
-		super(block, MachinePropertiesTesr.setRenderer(new Properties().tab(ItemGroupForestry.tabForestry), type));
+	public ItemBlockBase(B block, final IBlockTypeTesr blockTypeTesr) {
+		super(block, new Properties().tab(ItemGroupForestry.tabForestry));
+		this.blockTypeTesr = blockTypeTesr;
 	}
 
+	// OnlyIn client?
+	@Override
+	public void initializeClient(Consumer<IItemRenderProperties> consumer) {
+		final var renderItem = new RenderForestryItemProperties(this);
+		consumer.accept(renderItem);
+	}
 }

--- a/src/main/java/forestry/core/proxy/ProxyRender.java
+++ b/src/main/java/forestry/core/proxy/ProxyRender.java
@@ -10,9 +10,6 @@
  ******************************************************************************/
 package forestry.core.proxy;
 
-import net.minecraft.world.item.Item;
-
-import forestry.core.blocks.IBlockType;
 import forestry.core.blocks.MachinePropertiesTesr;
 import forestry.core.tiles.TileAnalyzer;
 import forestry.core.tiles.TileBase;
@@ -46,8 +43,5 @@ public class ProxyRender implements ISidedModuleHandler {
 	}
 
 	public void registerItemAndBlockColors() {
-	}
-
-	public void setRenderer(Item.Properties properties, IBlockType type) {
 	}
 }

--- a/src/main/java/forestry/core/proxy/ProxyRenderClient.java
+++ b/src/main/java/forestry/core/proxy/ProxyRenderClient.java
@@ -82,27 +82,27 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 
 	@Override
 	public void setRenderDefaultMachine(MachinePropertiesTesr<? extends TileBase> machineProperties, String baseTexture) {
-		machineProperties.setRenderer(ctx -> new RenderMachine(ctx, baseTexture));
+		machineProperties.setRenderer(RenderMachine.MODEL_LAYER, part -> new RenderMachine(part, baseTexture));
 	}
 
 	@Override
 	public void setRenderMill(MachinePropertiesTesr<? extends TileMill> machineProperties, String baseTexture) {
-		machineProperties.setRenderer(ctx -> new RenderMill(baseTexture));
+		machineProperties.setRenderer(RenderMill.MODEL_LAYER, part -> new RenderMill(baseTexture));
 	}
 
 	@Override
 	public void setRenderEscritoire(MachinePropertiesTesr<? extends TileEscritoire> machineProperties) {
-		machineProperties.setRenderer(ctx -> new RenderEscritoire());
+		machineProperties.setRenderer(RenderEscritoire.MODEL_LAYER, part -> new RenderEscritoire());
 	}
 
 	@Override
 	public void setRendererAnalyzer(MachinePropertiesTesr<? extends TileAnalyzer> machineProperties) {
-		machineProperties.setRenderer(RenderAnalyzer::new);
+		machineProperties.setRenderer(RenderAnalyzer.MODEL_LAYER, RenderAnalyzer::new);
 	}
 
 	@Override
 	public void setRenderChest(MachinePropertiesTesr<? extends TileNaturalistChest> machineProperties, String textureName) {
-		machineProperties.setRenderer(ctx -> new RenderNaturalistChest(textureName));
+		machineProperties.setRenderer(RenderNaturalistChest.MODEL_LAYER, part -> new RenderNaturalistChest(textureName));
 	}
 
 	@Override
@@ -124,7 +124,7 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 	
 	@Override
 	public void setupLayers(EntityRenderersEvent.RegisterLayerDefinitions event) {
-		event.registerLayerDefinition(RenderAnalyzer.ANALYZER, RenderAnalyzer::createBodyLayer);
-		event.registerLayerDefinition(RenderMachine.MACHINE, RenderMachine::createBodyLayer);
+		event.registerLayerDefinition(RenderAnalyzer.MODEL_LAYER, RenderAnalyzer::createBodyLayer);
+		event.registerLayerDefinition(RenderMachine.MODEL_LAYER, RenderMachine::createBodyLayer);
 	}
 }

--- a/src/main/java/forestry/core/proxy/ProxyRenderClient.java
+++ b/src/main/java/forestry/core/proxy/ProxyRenderClient.java
@@ -16,7 +16,6 @@ import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.ModelRegistryEvent;
@@ -25,9 +24,6 @@ import net.minecraftforge.client.model.ModelLoaderRegistry;
 
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 
-import forestry.core.blocks.IBlockType;
-import forestry.core.blocks.IMachineProperties;
-import forestry.core.blocks.IMachinePropertiesTesr;
 import forestry.core.blocks.MachinePropertiesTesr;
 import forestry.core.config.Constants;
 import forestry.core.features.CoreBlocks;
@@ -45,7 +41,6 @@ import forestry.core.tiles.TileBase;
 import forestry.core.tiles.TileEscritoire;
 import forestry.core.tiles.TileMill;
 import forestry.core.tiles.TileNaturalistChest;
-import forestry.energy.render.RenderEngine;
 import forestry.modules.IClientModuleHandler;
 
 public class ProxyRenderClient extends ProxyRender implements IClientModuleHandler {
@@ -109,22 +104,14 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 	public void registerItemAndBlockColors() {
 		ClientManager.getInstance().registerItemAndBlockColors();
 	}
-
-	@Override
-	public void setRenderer(Item.Properties properties, IBlockType type) {
-		IMachineProperties<?> machineProperties = type.getMachineProperties();
-		if (!(machineProperties instanceof IMachinePropertiesTesr<?> machinePropertiesTesr)) {
-			return;
-		}
-		if (machinePropertiesTesr.getRenderer() == null) {
-			return;
-		}
-		// properties.setISTER(() -> () -> new RenderForestryItem(machinePropertiesTesr.getRenderer()));
-	}
 	
 	@Override
 	public void setupLayers(EntityRenderersEvent.RegisterLayerDefinitions event) {
 		event.registerLayerDefinition(RenderAnalyzer.MODEL_LAYER, RenderAnalyzer::createBodyLayer);
 		event.registerLayerDefinition(RenderMachine.MODEL_LAYER, RenderMachine::createBodyLayer);
+		
+		event.registerLayerDefinition(RenderNaturalistChest.MODEL_LAYER, RenderMachine::createBodyLayer);
+		event.registerLayerDefinition(RenderEscritoire.MODEL_LAYER, RenderMachine::createBodyLayer);
+		event.registerLayerDefinition(RenderMill.MODEL_LAYER, RenderMachine::createBodyLayer);
 	}
 }

--- a/src/main/java/forestry/core/proxy/ProxyRenderClient.java
+++ b/src/main/java/forestry/core/proxy/ProxyRenderClient.java
@@ -17,7 +17,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
-
+import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.ModelBakeEvent;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ForgeModelBakery;
@@ -45,6 +45,7 @@ import forestry.core.tiles.TileBase;
 import forestry.core.tiles.TileEscritoire;
 import forestry.core.tiles.TileMill;
 import forestry.core.tiles.TileNaturalistChest;
+import forestry.energy.render.RenderEngine;
 import forestry.modules.IClientModuleHandler;
 
 public class ProxyRenderClient extends ProxyRender implements IClientModuleHandler {
@@ -81,28 +82,27 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 
 	@Override
 	public void setRenderDefaultMachine(MachinePropertiesTesr<? extends TileBase> machineProperties, String baseTexture) {
-		machineProperties.setRenderer(new RenderMachine(baseTexture));
+		machineProperties.setRenderer(ctx -> new RenderMachine(ctx, baseTexture));
 	}
 
 	@Override
 	public void setRenderMill(MachinePropertiesTesr<? extends TileMill> machineProperties, String baseTexture) {
-		machineProperties.setRenderer(new RenderMill(baseTexture));
+		machineProperties.setRenderer(ctx -> new RenderMill(baseTexture));
 	}
 
 	@Override
 	public void setRenderEscritoire(MachinePropertiesTesr<? extends TileEscritoire> machineProperties) {
-		machineProperties.setRenderer(new RenderEscritoire());
+		machineProperties.setRenderer(ctx -> new RenderEscritoire());
 	}
 
 	@Override
 	public void setRendererAnalyzer(MachinePropertiesTesr<? extends TileAnalyzer> machineProperties) {
-		RenderAnalyzer renderAnalyzer = new RenderAnalyzer();
-		machineProperties.setRenderer(renderAnalyzer);
+		machineProperties.setRenderer(RenderAnalyzer::new);
 	}
 
 	@Override
 	public void setRenderChest(MachinePropertiesTesr<? extends TileNaturalistChest> machineProperties, String textureName) {
-		machineProperties.setRenderer(new RenderNaturalistChest(textureName));
+		machineProperties.setRenderer(ctx -> new RenderNaturalistChest(textureName));
 	}
 
 	@Override
@@ -120,5 +120,10 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 			return;
 		}
 		// properties.setISTER(() -> () -> new RenderForestryItem(machinePropertiesTesr.getRenderer()));
+	}
+	
+	@Override
+	public void setupLayers(EntityRenderersEvent.RegisterLayerDefinitions event) {
+		event.registerLayerDefinition(RenderMachine.MACHINE, RenderMachine::createBodyLayer);
 	}
 }

--- a/src/main/java/forestry/core/proxy/ProxyRenderClient.java
+++ b/src/main/java/forestry/core/proxy/ProxyRenderClient.java
@@ -124,6 +124,7 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 	
 	@Override
 	public void setupLayers(EntityRenderersEvent.RegisterLayerDefinitions event) {
+		event.registerLayerDefinition(RenderAnalyzer.ANALYZER, RenderAnalyzer::createBodyLayer);
 		event.registerLayerDefinition(RenderMachine.MACHINE, RenderMachine::createBodyLayer);
 	}
 }

--- a/src/main/java/forestry/core/proxy/ProxyRenderClient.java
+++ b/src/main/java/forestry/core/proxy/ProxyRenderClient.java
@@ -82,12 +82,12 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 
 	@Override
 	public void setRenderMill(MachinePropertiesTesr<? extends TileMill> machineProperties, String baseTexture) {
-		machineProperties.setRenderer(RenderMill.MODEL_LAYER, part -> new RenderMill(baseTexture));
+		machineProperties.setRenderer(RenderMill.MODEL_LAYER, part -> new RenderMill(part, baseTexture));
 	}
 
 	@Override
 	public void setRenderEscritoire(MachinePropertiesTesr<? extends TileEscritoire> machineProperties) {
-		machineProperties.setRenderer(RenderEscritoire.MODEL_LAYER, part -> new RenderEscritoire());
+		machineProperties.setRenderer(RenderEscritoire.MODEL_LAYER, RenderEscritoire::new);
 	}
 
 	@Override
@@ -97,7 +97,7 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 
 	@Override
 	public void setRenderChest(MachinePropertiesTesr<? extends TileNaturalistChest> machineProperties, String textureName) {
-		machineProperties.setRenderer(RenderNaturalistChest.MODEL_LAYER, part -> new RenderNaturalistChest(textureName));
+		machineProperties.setRenderer(RenderNaturalistChest.MODEL_LAYER, part -> new RenderNaturalistChest(part, textureName));
 	}
 
 	@Override
@@ -110,8 +110,8 @@ public class ProxyRenderClient extends ProxyRender implements IClientModuleHandl
 		event.registerLayerDefinition(RenderAnalyzer.MODEL_LAYER, RenderAnalyzer::createBodyLayer);
 		event.registerLayerDefinition(RenderMachine.MODEL_LAYER, RenderMachine::createBodyLayer);
 		
-		event.registerLayerDefinition(RenderNaturalistChest.MODEL_LAYER, RenderMachine::createBodyLayer);
-		event.registerLayerDefinition(RenderEscritoire.MODEL_LAYER, RenderMachine::createBodyLayer);
-		event.registerLayerDefinition(RenderMill.MODEL_LAYER, RenderMachine::createBodyLayer);
+		event.registerLayerDefinition(RenderNaturalistChest.MODEL_LAYER, RenderNaturalistChest::createBodyLayer);
+		event.registerLayerDefinition(RenderEscritoire.MODEL_LAYER, RenderEscritoire::createBodyLayer);
+		event.registerLayerDefinition(RenderMill.MODEL_LAYER, RenderMill::createBodyLayer);
 	}
 }

--- a/src/main/java/forestry/core/render/IForestryRenderer.java
+++ b/src/main/java/forestry/core/render/IForestryRenderer.java
@@ -1,5 +1,6 @@
 package forestry.core.render;
 
+import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
@@ -9,6 +10,9 @@ import net.minecraft.world.level.block.entity.BlockEntity;
  * @param <T> The type of the tile entity
  */
 public interface IForestryRenderer<T extends BlockEntity> {
+	public static ModelLayerLocation register(String name) {
+		return new ModelLayerLocation(new ForestryResource(name), "main");
+	}
 
 	/**
 	 * Renders the given tile entity.

--- a/src/main/java/forestry/core/render/IForestryRendererProvider.java
+++ b/src/main/java/forestry/core/render/IForestryRendererProvider.java
@@ -1,6 +1,6 @@
 package forestry.core.render;
 
-import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.world.level.block.entity.BlockEntity;
 
 /**
@@ -10,5 +10,5 @@ import net.minecraft.world.level.block.entity.BlockEntity;
  */
 @FunctionalInterface
 public interface IForestryRendererProvider<T extends BlockEntity> {
-	IForestryRenderer<? super T> create(BlockEntityRendererProvider.Context ctx);
+	IForestryRenderer<? super T> create(ModelPart root);
 }

--- a/src/main/java/forestry/core/render/IForestryRendererProvider.java
+++ b/src/main/java/forestry/core/render/IForestryRendererProvider.java
@@ -1,0 +1,14 @@
+package forestry.core.render;
+
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.world.level.block.entity.BlockEntity;
+
+/**
+ * Constructor to register IForestryRenderer
+ *
+ * @param <T> The type of the tile entity
+ */
+@FunctionalInterface
+public interface IForestryRendererProvider<T extends BlockEntity> {
+	IForestryRenderer<? super T> create(BlockEntityRendererProvider.Context ctx);
+}

--- a/src/main/java/forestry/core/render/RenderAnalyzer.java
+++ b/src/main/java/forestry/core/render/RenderAnalyzer.java
@@ -12,7 +12,16 @@ package forestry.core.render;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -20,11 +29,54 @@ import net.minecraft.world.level.block.state.BlockState;
 import com.mojang.math.Vector3f;
 
 import forestry.core.blocks.BlockBase;
+import forestry.core.config.Constants;
 import forestry.core.tiles.TileAnalyzer;
 
 public class RenderAnalyzer implements IForestryRenderer<TileAnalyzer> {
+	public static final ModelLayerLocation ANALYZER = IForestryRenderer.register("analyzer");
+	
+	private static final String TOWER2 = "tower2";
+	private static final String TOWER1 = "tower1";
+	private static final String COVER = "cover";
+	private static final String PEDESTAL = "pedestal";
+	private final ModelPart pedestal;
+	private final ModelPart cover;
+	private final ModelPart tower1;
+	private final ModelPart tower2;
 
-	public RenderAnalyzer() {
+	private final ResourceLocation[] textures;
+
+	public RenderAnalyzer(BlockEntityRendererProvider.Context ctx) {
+		// registerLayerDefinitions(EntityRenderersEvent.RegisterLayerDefinitions event)
+		// event.registerLayerDefinition(RenderAnalyzer.ANALYZER, RenderAnalyzer::createBodyLayer);
+		
+        ModelPart root = ctx.bakeLayer(ANALYZER);
+        this.pedestal = root.getChild(PEDESTAL);
+        this.cover = root.getChild(COVER);
+        this.tower1 = root.getChild(TOWER1);
+        this.tower2 = root.getChild(TOWER2);
+        
+        textures = new ResourceLocation[]{
+				new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/analyzer_pedestal.png"),
+				new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/analyzer_tower1.png"),
+				new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/analyzer_tower2.png"),
+		};
+	}
+	
+	public static LayerDefinition createBodyLayer() {
+		MeshDefinition meshdefinition = new MeshDefinition();
+        PartDefinition partdefinition = meshdefinition.getRoot();
+        
+        partdefinition.addOrReplaceChild(PEDESTAL, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-8F, -8F, -8F, 16, 1, 16), PartPose.offset(8, 8, 8));
+        partdefinition.addOrReplaceChild(COVER, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-8F, -8F, -8F, 16, 1, 16), PartPose.offset(8, 8, 8)); 
+        partdefinition.addOrReplaceChild(TOWER1, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-8, -7, -7, 2, 14, 14), PartPose.offset(8, 8, 8));
+        partdefinition.addOrReplaceChild(TOWER2, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(6, -7, -7, 2, 14, 14), PartPose.offset(8, 8, 8));
+        
+        return LayerDefinition.create(meshdefinition, 64, 32);
 	}
 
 	@Override
@@ -61,6 +113,12 @@ public class RenderAnalyzer implements IForestryRenderer<TileAnalyzer> {
 		helper.setRotation(rotation);
 		helper.push();
 
+		helper.renderModel(textures[0], pedestal);
+		helper.renderModel(textures[0], new Vector3f(0, 0, (float) Math.PI), cover);
+
+		helper.renderModel(textures[1], tower1);
+
+		helper.renderModel(textures[2], tower2);
 		helper.pop();
 		if (itemstack.isEmpty() || world == null) {
 			return;

--- a/src/main/java/forestry/core/render/RenderAnalyzer.java
+++ b/src/main/java/forestry/core/render/RenderAnalyzer.java
@@ -33,7 +33,7 @@ import forestry.core.config.Constants;
 import forestry.core.tiles.TileAnalyzer;
 
 public class RenderAnalyzer implements IForestryRenderer<TileAnalyzer> {
-	public static final ModelLayerLocation ANALYZER = IForestryRenderer.register("analyzer");
+	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("analyzer");
 	
 	private static final String TOWER2 = "tower2";
 	private static final String TOWER1 = "tower1";
@@ -46,8 +46,7 @@ public class RenderAnalyzer implements IForestryRenderer<TileAnalyzer> {
 
 	private final ResourceLocation[] textures;
 
-	public RenderAnalyzer(BlockEntityRendererProvider.Context ctx) {
-        ModelPart root = ctx.bakeLayer(ANALYZER);
+	public RenderAnalyzer(final ModelPart root) {
         this.pedestal = root.getChild(PEDESTAL);
         this.cover = root.getChild(COVER);
         this.tower1 = root.getChild(TOWER1);

--- a/src/main/java/forestry/core/render/RenderAnalyzer.java
+++ b/src/main/java/forestry/core/render/RenderAnalyzer.java
@@ -47,9 +47,6 @@ public class RenderAnalyzer implements IForestryRenderer<TileAnalyzer> {
 	private final ResourceLocation[] textures;
 
 	public RenderAnalyzer(BlockEntityRendererProvider.Context ctx) {
-		// registerLayerDefinitions(EntityRenderersEvent.RegisterLayerDefinitions event)
-		// event.registerLayerDefinition(RenderAnalyzer.ANALYZER, RenderAnalyzer::createBodyLayer);
-		
         ModelPart root = ctx.bakeLayer(ANALYZER);
         this.pedestal = root.getChild(PEDESTAL);
         this.cover = root.getChild(COVER);

--- a/src/main/java/forestry/core/render/RenderEscritoire.java
+++ b/src/main/java/forestry/core/render/RenderEscritoire.java
@@ -12,25 +12,82 @@ package forestry.core.render;
 
 import javax.annotation.Nullable;
 
+import com.mojang.math.Vector3f;
+
+import forestry.core.blocks.BlockBase;
+import forestry.core.config.Constants;
+import forestry.core.tiles.TileEscritoire;
 import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
-import com.mojang.math.Vector3f;
-
-import forestry.core.blocks.BlockBase;
-import forestry.core.config.Constants;
-import forestry.core.tiles.TileEscritoire;
-
 public class RenderEscritoire implements IForestryRenderer<TileEscritoire> {
 	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("escritoire");
 
 	private static final ResourceLocation TEXTURE = new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/escritoire.png");
 
-	public RenderEscritoire() {
+	private enum Parts {
+		DESK, STANDRB, STANDRF, STANDLB, STANDLF, DRAWERS, STANDLOWLF, STANDLOWRB, STANDLOWRF, STANDLOWLB
+	}
+	private final ModelPart desk;
+	private final ModelPart standRB;
+	private final ModelPart standRF;
+	private final ModelPart standLB;
+	private final ModelPart standLF;
+	private final ModelPart drawers;
+	private final ModelPart standLowLF;
+	private final ModelPart standLowRB;
+	private final ModelPart standLowRF;
+	private final ModelPart standLowLB;
+	
+	public RenderEscritoire(ModelPart root) {
+		desk = root.getChild(Parts.DESK.name());
+		standRB = root.getChild(Parts.STANDRB.name());
+		standRF = root.getChild(Parts.STANDRF.name());
+		standLB = root.getChild(Parts.STANDLB.name());
+		standLF = root.getChild(Parts.STANDLF.name());
+		drawers = root.getChild(Parts.DRAWERS.name());
+		standLowRB = root.getChild(Parts.STANDLOWRB.name());
+		standLowRF = root.getChild(Parts.STANDLOWRF.name());
+		standLowLB = root.getChild(Parts.STANDLOWLB.name());
+		standLowLF = root.getChild(Parts.STANDLOWLF.name());
+	}
+	
+	public static LayerDefinition createBodyLayer() {
+		MeshDefinition meshdefinition = new MeshDefinition();
+        PartDefinition partdefinition = meshdefinition.getRoot();
+        
+        partdefinition.addOrReplaceChild(Parts.DESK.name(), CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-8F, 3F, -7.8F, 16, 2, 15).mirror(), PartPose.offset(0, 0, 0));
+        partdefinition.addOrReplaceChild(Parts.STANDRB.name(), CubeListBuilder.create().texOffs(38, 18)
+            	.addBox(5F, 4F, 5F, 2, 6, 2).mirror(), PartPose.offset(0, 0, 0));
+        partdefinition.addOrReplaceChild(Parts.STANDRF.name(), CubeListBuilder.create().texOffs(38, 18)
+            	.addBox(5F, 4F, -7F, 2, 6, 2).mirror(), PartPose.offset(0, 0, 0));
+        partdefinition.addOrReplaceChild(Parts.STANDLB.name(), CubeListBuilder.create().texOffs(38, 18)
+            	.addBox(-7F, 4F, 5F, 2, 6, 2).mirror(), PartPose.offset(0, 0, 0));        
+        partdefinition.addOrReplaceChild(Parts.STANDLF.name(), CubeListBuilder.create().texOffs(38, 18)
+            	.addBox(-7F, 4F, -7F, 2, 6, 2).mirror(), PartPose.offset(0, 0, 0));
+        partdefinition.addOrReplaceChild(Parts.DRAWERS.name(), CubeListBuilder.create().texOffs(0, 18)
+            	.addBox(-7.5F, -2F, 4.5F, 15, 5, 3).mirror(), PartPose.offset(0, 0, 0)); 
+        partdefinition.addOrReplaceChild(Parts.STANDLOWRB.name(), CubeListBuilder.create().texOffs(0, 26)
+            	.addBox(5.5F, 10F, 5.5F, 1, 4, 1).mirror(), PartPose.offset(0, 0, 0)); 
+        partdefinition.addOrReplaceChild(Parts.STANDLOWRF.name(), CubeListBuilder.create().texOffs(0, 26)
+            	.addBox(5.5F, 10F, -6.5F, 1, 4, 1).mirror(), PartPose.offset(0, 0, 0)); 
+        partdefinition.addOrReplaceChild(Parts.STANDLOWLB.name(), CubeListBuilder.create().texOffs(0, 26)
+            	.addBox(-6.5F, 10F, 5.5F, 1, 4, 1).mirror(), PartPose.offset(0, 0, 0)); 
+        partdefinition.addOrReplaceChild(Parts.STANDLOWLF.name(), CubeListBuilder.create().texOffs(0, 26)
+            	.addBox(-6.5F, 10F, -6.5F, 1, 4, 1).mirror(), PartPose.offset(0, 0, 0));
+		
+		return LayerDefinition.create(meshdefinition, 64, 32);
 	}
 
 	@Override
@@ -70,6 +127,9 @@ public class RenderEscritoire implements IForestryRenderer<TileEscritoire> {
 					break;
 			}
 			helper.setRotation(rotation);
+			helper.renderModel(TEXTURE, new Vector3f(0.0872665F, 0, 0), desk);
+			helper.renderModel(TEXTURE,
+				standRB, standRF, standLB, standLF, drawers, standLowLF, standLowRB, standLowRF, standLowLB);
 		}
 		helper.pop();
 

--- a/src/main/java/forestry/core/render/RenderEscritoire.java
+++ b/src/main/java/forestry/core/render/RenderEscritoire.java
@@ -12,6 +12,7 @@ package forestry.core.render;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
@@ -25,6 +26,7 @@ import forestry.core.config.Constants;
 import forestry.core.tiles.TileEscritoire;
 
 public class RenderEscritoire implements IForestryRenderer<TileEscritoire> {
+	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("escritoire");
 
 	private static final ResourceLocation TEXTURE = new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/escritoire.png");
 

--- a/src/main/java/forestry/core/render/RenderForestryItem.java
+++ b/src/main/java/forestry/core/render/RenderForestryItem.java
@@ -3,6 +3,7 @@ package forestry.core.render;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.model.geom.EntityModelSet;
+import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.block.model.ItemTransforms;
@@ -14,15 +15,17 @@ public class RenderForestryItem extends BlockEntityWithoutLevelRenderer {
 	private final IForestryRenderer<?> renderer;
 	private final RenderHelper helper = new RenderHelper();
 
-	public RenderForestryItem(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet, IForestryRenderer<?> renderer) {
+	public RenderForestryItem(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet, ModelLayerLocation modelLayer, IForestryRendererProvider<?> provider) {
 		super(pBlockEntityRenderDispatcher, pEntityModelSet);
-		this.renderer = renderer;
+		final var root = pEntityModelSet.bakeLayer(modelLayer);
+		this.renderer = provider.create(root);
 	}
 
 	@Override
 	public void renderByItem(ItemStack itemStack, ItemTransforms.TransformType transformType, PoseStack transform, MultiBufferSource buffer, int combinedLight, int packetLight) {
 		helper.update(0, transform, buffer, combinedLight, packetLight);
 		renderer.renderItem(itemStack, helper);
+		
 	}
 }
 

--- a/src/main/java/forestry/core/render/RenderForestryItem.java
+++ b/src/main/java/forestry/core/render/RenderForestryItem.java
@@ -1,0 +1,28 @@
+package forestry.core.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.model.geom.EntityModelSet;
+import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderDispatcher;
+import net.minecraft.world.item.ItemStack;
+ 
+public class RenderForestryItem extends BlockEntityWithoutLevelRenderer {
+
+	private final IForestryRenderer<?> renderer;
+	private final RenderHelper helper = new RenderHelper();
+
+	public RenderForestryItem(BlockEntityRenderDispatcher pBlockEntityRenderDispatcher, EntityModelSet pEntityModelSet, IForestryRenderer<?> renderer) {
+		super(pBlockEntityRenderDispatcher, pEntityModelSet);
+		this.renderer = renderer;
+	}
+
+	@Override
+	public void renderByItem(ItemStack itemStack, ItemTransforms.TransformType transformType, PoseStack transform, MultiBufferSource buffer, int combinedLight, int packetLight) {
+		helper.update(0, transform, buffer, combinedLight, packetLight);
+		renderer.renderItem(itemStack, helper);
+	}
+}
+

--- a/src/main/java/forestry/core/render/RenderForestryItemProperties.java
+++ b/src/main/java/forestry/core/render/RenderForestryItemProperties.java
@@ -1,0 +1,24 @@
+package forestry.core.render;
+
+import forestry.core.items.ItemBlockBase;
+import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
+import net.minecraftforge.client.IItemRenderProperties;
+import net.minecraftforge.common.util.NonNullLazy;
+
+public class RenderForestryItemProperties implements IItemRenderProperties {
+	private final NonNullLazy<RenderForestryItem> renderItem;
+
+	// initializeClient is called during ItemBlockBase super
+	// field itemBlock.blockTypeTesr is not initialized until after constructor done
+	// lazy has two purposes:
+	// - itemBlock.blockTypeTesr filled in after 
+	// - getEntityModels not available until later in loading
+	public RenderForestryItemProperties(ItemBlockBase<?> itemBlock) {
+		this.renderItem = NonNullLazy.of(() -> itemBlock.blockTypeTesr.initRenderItem());
+	}
+
+	@Override
+	public BlockEntityWithoutLevelRenderer getItemStackRenderer() {
+		return renderItem.get();
+	}
+}

--- a/src/main/java/forestry/core/render/RenderMachine.java
+++ b/src/main/java/forestry/core/render/RenderMachine.java
@@ -10,21 +10,88 @@
  ******************************************************************************/
 package forestry.core.render;
 
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.fluids.FluidAttributes;
+
+import java.awt.Color;
+import java.util.EnumMap;
+import java.util.Locale;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.math.Vector3f;
 
 import forestry.core.blocks.BlockBase;
+import forestry.core.config.Constants;
+import forestry.core.fluids.ForestryFluids;
 import forestry.core.tiles.IRenderableTile;
 import forestry.core.tiles.TileBase;
 
 public class RenderMachine implements IForestryRenderer<TileBase> {
+	// probably need one per machine?
+	public static final ModelLayerLocation MACHINE = IForestryRenderer.register("machine");
+	
+	private static final String BASE_FRONT = "basefront";
+	private static final String BASE_BACK = "baseback";
+	private static final String RESOURCE_TANK = "resourceTank";
+	private static final String PRODUCT_TANK = "productTank";
+	
+	private final ModelPart basefront;
+	private final ModelPart baseback;
+	private final ModelPart resourceTank;
+	private final ModelPart productTank;
 
-	public RenderMachine(String baseTexture) {
+	private final ResourceLocation textureBase;
+	private final ResourceLocation textureResourceTank;
+	private final ResourceLocation textureProductTank;
+
+	private final EnumMap<EnumTankLevel, ResourceLocation> texturesTankLevels = new EnumMap<>(EnumTankLevel.class);
+
+	public RenderMachine(BlockEntityRendererProvider.Context ctx, String baseTexture) {
+		ModelPart root = ctx.bakeLayer(MACHINE);
+		basefront = root.getChild(BASE_FRONT);
+		baseback = root.getChild(BASE_BACK);
+		resourceTank = root.getChild(RESOURCE_TANK);
+		productTank = root.getChild(PRODUCT_TANK);
+		
+		textureBase = new ResourceLocation(Constants.MOD_ID, baseTexture + "base.png");
+		textureProductTank = new ResourceLocation(Constants.MOD_ID, baseTexture + "tank_product_empty.png");
+		textureResourceTank = new ResourceLocation(Constants.MOD_ID, baseTexture + "tank_resource_empty.png");
+
+		for (EnumTankLevel tankLevel : EnumTankLevel.values()) {
+			if (tankLevel == EnumTankLevel.EMPTY) {
+				continue;
+			}
+			String tankLevelString = tankLevel.toString().toLowerCase(Locale.ENGLISH);
+			texturesTankLevels.put(tankLevel, new ResourceLocation(Constants.MOD_ID, "textures/block/machine_tank_" + tankLevelString + ".png"));
+		}
+	}
+	
+	public static LayerDefinition createBodyLayer() {
+		MeshDefinition meshdefinition = new MeshDefinition();
+        PartDefinition partdefinition = meshdefinition.getRoot();
+        
+        partdefinition.addOrReplaceChild(BASE_FRONT, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-8F, -8F, -8F, 16, 4, 16), PartPose.offset(8, 8, 8));
+        partdefinition.addOrReplaceChild(BASE_BACK, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-8F, 4F, -8F, 16, 4, 16), PartPose.offset(8, 8, 8));
+        partdefinition.addOrReplaceChild(RESOURCE_TANK, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-6F, -8F, -6F, 12, 16, 6), PartPose.offset(8, 8, 8));
+        partdefinition.addOrReplaceChild(PRODUCT_TANK, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-6F, -8F, 0F, 12, 16, 6), PartPose.offset(8, 8, 8));
+		
+		return LayerDefinition.create(meshdefinition, 64, 32);
 	}
 
 	@Override
@@ -68,7 +135,39 @@ public class RenderMachine implements IForestryRenderer<TileBase> {
 		}
 
 		helper.setRotation(rotation);
+		helper.renderModel(textureBase, basefront, baseback);
+
+		renderTank(resourceTank, textureResourceTank, resourceTankInfo, helper);
+		renderTank(productTank, textureProductTank, productTankInfo, helper);
 
 		RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+	}
+
+	private void renderTank(ModelPart tankModel, ResourceLocation textureBase, TankRenderInfo renderInfo, RenderHelper helper) {
+		helper.renderModel(textureBase, tankModel);
+
+		ResourceLocation textureResourceTankLevel = texturesTankLevels.get(renderInfo.getLevel());
+		if (textureResourceTankLevel == null) {
+			return;
+		}
+
+		FluidAttributes attributes = renderInfo.getFluidStack().getFluid().getAttributes();
+		int color = attributes.getColor();
+		ForestryFluids definition = ForestryFluids.getFluidDefinition(renderInfo.getFluidStack().getFluid());
+		if (color < 0) {
+			color = Color.BLUE.getRGB();
+			if (definition != null) {
+				color = definition.getParticleColor().getRGB();
+			}
+		}
+		float[] colors = new float[3];
+		colors[0] = (color >> 16 & 255) / 255f;
+		colors[1] = (color >> 8 & 255) / 255f;
+		colors[2] = (color & 255) / 255f;
+		helper.color(colors[0], colors[1], colors[2], 1.0f);
+
+		helper.renderModel(textureResourceTankLevel, tankModel);
+
+		helper.color(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 }

--- a/src/main/java/forestry/core/render/RenderMachine.java
+++ b/src/main/java/forestry/core/render/RenderMachine.java
@@ -17,7 +17,6 @@ import net.minecraft.client.model.geom.builders.CubeListBuilder;
 import net.minecraft.client.model.geom.builders.LayerDefinition;
 import net.minecraft.client.model.geom.builders.MeshDefinition;
 import net.minecraft.client.model.geom.builders.PartDefinition;
-import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
@@ -39,8 +38,7 @@ import forestry.core.tiles.IRenderableTile;
 import forestry.core.tiles.TileBase;
 
 public class RenderMachine implements IForestryRenderer<TileBase> {
-	// probably need one per machine?
-	public static final ModelLayerLocation MACHINE = IForestryRenderer.register("machine");
+	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("machine");
 	
 	private static final String BASE_FRONT = "basefront";
 	private static final String BASE_BACK = "baseback";
@@ -58,8 +56,7 @@ public class RenderMachine implements IForestryRenderer<TileBase> {
 
 	private final EnumMap<EnumTankLevel, ResourceLocation> texturesTankLevels = new EnumMap<>(EnumTankLevel.class);
 
-	public RenderMachine(BlockEntityRendererProvider.Context ctx, String baseTexture) {
-		ModelPart root = ctx.bakeLayer(MACHINE);
+	public RenderMachine(ModelPart root, String baseTexture) {
 		basefront = root.getChild(BASE_FRONT);
 		baseback = root.getChild(BASE_BACK);
 		resourceTank = root.getChild(RESOURCE_TANK);

--- a/src/main/java/forestry/core/render/RenderMill.java
+++ b/src/main/java/forestry/core/render/RenderMill.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.core.render;
 
+import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 
@@ -18,6 +19,8 @@ import com.mojang.math.Vector3f;
 import forestry.core.tiles.TileMill;
 
 public class RenderMill implements IForestryRenderer<TileMill> {
+	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("mill");
+	
 	private enum Textures {PEDESTAL, EXTENSION, BLADE_1, BLADE_2, CHARGE}
 
 	public RenderMill(String baseTexture) {

--- a/src/main/java/forestry/core/render/RenderNaturalistChest.java
+++ b/src/main/java/forestry/core/render/RenderNaturalistChest.java
@@ -23,7 +23,7 @@ import forestry.core.blocks.BlockBase;
 import forestry.core.tiles.TileNaturalistChest;
 
 public class RenderNaturalistChest implements IForestryRenderer<TileNaturalistChest> {
-	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("naturalistChest");
+	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("naturalistchest");
 
 	public RenderNaturalistChest(String textureName) {
 	}

--- a/src/main/java/forestry/core/render/RenderNaturalistChest.java
+++ b/src/main/java/forestry/core/render/RenderNaturalistChest.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package forestry.core.render;
 
+import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
@@ -22,6 +23,7 @@ import forestry.core.blocks.BlockBase;
 import forestry.core.tiles.TileNaturalistChest;
 
 public class RenderNaturalistChest implements IForestryRenderer<TileNaturalistChest> {
+	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("naturalistChest");
 
 	public RenderNaturalistChest(String textureName) {
 	}

--- a/src/main/java/forestry/core/render/RenderNaturalistChest.java
+++ b/src/main/java/forestry/core/render/RenderNaturalistChest.java
@@ -10,22 +10,56 @@
  ******************************************************************************/
 package forestry.core.render;
 
-import net.minecraft.client.model.geom.ModelLayerLocation;
-import net.minecraft.core.Direction;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.state.BlockState;
-
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.math.Vector3f;
 
 import forestry.core.blocks.BlockBase;
+import forestry.core.config.Constants;
 import forestry.core.tiles.TileNaturalistChest;
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 
 public class RenderNaturalistChest implements IForestryRenderer<TileNaturalistChest> {
 	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("naturalistchest");
 
-	public RenderNaturalistChest(String textureName) {
+	private static final String LID = "lid";
+	private static final String BASE = "base";
+	private static final String LOCK = "lock";
+	
+	private final ModelPart lid;
+	private final ModelPart base;
+	private final ModelPart lock;
+	private final ResourceLocation texture;
+	
+	public RenderNaturalistChest(ModelPart root, String textureName) {
+		this.lid = root.getChild(LID);
+		this.base = root.getChild(BASE);
+		this.lock = root.getChild(LOCK);
+		texture = new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/" + textureName + ".png");
+	}
+	
+	public static LayerDefinition createBodyLayer() {
+		MeshDefinition meshdefinition = new MeshDefinition();
+        PartDefinition partdefinition = meshdefinition.getRoot();
+        
+        partdefinition.addOrReplaceChild(BASE, CubeListBuilder.create().texOffs(0, 19)
+            	.addBox(1.0F, 0.0F, 1.0F, 14.0F, 10.0F, 14.0F/*, 0.0F*/), PartPose.offset(0, 0, 0));
+        partdefinition.addOrReplaceChild(LID, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(1.0F, 0.0F, 0.0F, 14.0F, 5.0F, 14.0F/*, 0.0F*/), PartPose.offset(0, 9.0F, 1.0F));
+        partdefinition.addOrReplaceChild(LOCK, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(7.0F, -1.0F, 15.0F, 2.0F, 4.0F, 1.0F/*, 0.0F*/), PartPose.offset(0, 8.0F, 0));
+		
+		return LayerDefinition.create(meshdefinition, 64, 64);
 	}
 
 	@Override
@@ -55,6 +89,8 @@ public class RenderNaturalistChest implements IForestryRenderer<TileNaturalistCh
 		angle = 1.0F - angle;
 		angle = 1.0F - angle * angle * angle;
 		float rotation = -(angle * (float) Math.PI / 2.0F);
+		helper.renderModel(texture, new Vector3f(rotation, 0.0F, 0.0F), lid, lock);
+		helper.renderModel(texture, base);
 
 		helper.pop();
 	}

--- a/src/main/java/forestry/energy/ModuleEnergy.java
+++ b/src/main/java/forestry/energy/ModuleEnergy.java
@@ -24,6 +24,7 @@ import forestry.energy.proxy.ProxyEnergy;
 import forestry.energy.proxy.ProxyEnergyClient;
 import forestry.modules.BlankForestryModule;
 import forestry.modules.ForestryModuleUids;
+import forestry.modules.ISidedModuleHandler;
 
 @ForestryModule(containerID = Constants.MOD_ID, moduleID = ForestryModuleUids.ENERGY, name = "Energy", author = "SirSengir", url = Constants.URL, unlocalizedDescription = "for.module.energy.description")
 public class ModuleEnergy extends BlankForestryModule {
@@ -42,5 +43,9 @@ public class ModuleEnergy extends BlankForestryModule {
 		MenuScreens.register(EnergyContainers.ENGINE_BIOGAS.containerType(), GuiEngineBiogas::new);
 		MenuScreens.register(EnergyContainers.ENGINE_PEAT.containerType(), GuiEnginePeat::new);
 	}
-
+	
+	@Override
+	public ISidedModuleHandler getModuleHandler() {
+		return proxy;
+	}
 }

--- a/src/main/java/forestry/energy/proxy/ProxyEnergy.java
+++ b/src/main/java/forestry/energy/proxy/ProxyEnergy.java
@@ -12,8 +12,9 @@ package forestry.energy.proxy;
 
 import forestry.core.blocks.MachinePropertiesTesr;
 import forestry.energy.tiles.TileEngine;
+import forestry.modules.ISidedModuleHandler;
 
-public class ProxyEnergy {
+public class ProxyEnergy implements ISidedModuleHandler {
 	public void setRenderDefaultEngine(MachinePropertiesTesr<? extends TileEngine> machineProperties, String gfxBase) {
 
 	}

--- a/src/main/java/forestry/energy/proxy/ProxyEnergyClient.java
+++ b/src/main/java/forestry/energy/proxy/ProxyEnergyClient.java
@@ -13,16 +13,22 @@ package forestry.energy.proxy;
 
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-
+import net.minecraftforge.client.event.EntityRenderersEvent;
 import forestry.core.blocks.MachinePropertiesTesr;
 import forestry.energy.render.RenderEngine;
 import forestry.energy.tiles.TileEngine;
+import forestry.modules.IClientModuleHandler;
 
 @SuppressWarnings("unused")
 @OnlyIn(Dist.CLIENT)
-public class ProxyEnergyClient extends ProxyEnergy {
+public class ProxyEnergyClient extends ProxyEnergy implements IClientModuleHandler {
 	@Override
 	public void setRenderDefaultEngine(MachinePropertiesTesr<? extends TileEngine> machineProperties, String baseTexture) {
-		machineProperties.setRenderer(new RenderEngine(baseTexture));
+		machineProperties.setRenderer(ctx -> new RenderEngine(ctx, baseTexture));
+	}
+	
+	@Override
+	public void setupLayers(EntityRenderersEvent.RegisterLayerDefinitions event) {
+		event.registerLayerDefinition(RenderEngine.ENGINE, RenderEngine::createBodyLayer);
 	}
 }

--- a/src/main/java/forestry/energy/proxy/ProxyEnergyClient.java
+++ b/src/main/java/forestry/energy/proxy/ProxyEnergyClient.java
@@ -24,11 +24,11 @@ import forestry.modules.IClientModuleHandler;
 public class ProxyEnergyClient extends ProxyEnergy implements IClientModuleHandler {
 	@Override
 	public void setRenderDefaultEngine(MachinePropertiesTesr<? extends TileEngine> machineProperties, String baseTexture) {
-		machineProperties.setRenderer(ctx -> new RenderEngine(ctx, baseTexture));
+		machineProperties.setRenderer(RenderEngine.MODEL_LAYER, part -> new RenderEngine(part, baseTexture));
 	}
 	
 	@Override
 	public void setupLayers(EntityRenderersEvent.RegisterLayerDefinitions event) {
-		event.registerLayerDefinition(RenderEngine.ENGINE, RenderEngine::createBodyLayer);
+		event.registerLayerDefinition(RenderEngine.MODEL_LAYER, RenderEngine::createBodyLayer);
 	}
 }

--- a/src/main/java/forestry/energy/render/RenderEngine.java
+++ b/src/main/java/forestry/energy/render/RenderEngine.java
@@ -34,7 +34,7 @@ import forestry.core.tiles.TemperatureState;
 import forestry.energy.tiles.TileEngine;
 
 public class RenderEngine implements IForestryRenderer<TileEngine> {
-	public static final ModelLayerLocation ENGINE = IForestryRenderer.register("engine");
+	public static final ModelLayerLocation MODEL_LAYER = IForestryRenderer.register("engine");
 	
 	private static final String EXTENSION = "EXTENSION";
 	private static final String PISTON = "PISTON";
@@ -63,8 +63,7 @@ public class RenderEngine implements IForestryRenderer<TileEngine> {
 		angleMap[Direction.NORTH.ordinal()] = (float) -Math.PI / 2;
 	}
 
-	public RenderEngine(BlockEntityRendererProvider.Context ctx, String baseTexture) {
-		ModelPart root = ctx.bakeLayer(ENGINE);
+	public RenderEngine(final ModelPart root, String baseTexture) {
 		boiler = root.getChild(BOILER);
 		trunk = root.getChild(TRUNK);
 		piston = root.getChild(PISTON);

--- a/src/main/java/forestry/energy/render/RenderEngine.java
+++ b/src/main/java/forestry/energy/render/RenderEngine.java
@@ -11,14 +11,19 @@
 package forestry.energy.render;
 
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.model.geom.ModelPart;
+import net.minecraft.client.model.geom.PartPose;
+import net.minecraft.client.model.geom.builders.CubeListBuilder;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.model.geom.builders.MeshDefinition;
+import net.minecraft.client.model.geom.builders.PartDefinition;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
 import com.mojang.math.Vector3f;
 import net.minecraft.world.level.Level;
-
-import com.mojang.blaze3d.systems.RenderSystem;
 
 import forestry.core.blocks.BlockBase;
 import forestry.core.config.Constants;
@@ -29,7 +34,20 @@ import forestry.core.tiles.TemperatureState;
 import forestry.energy.tiles.TileEngine;
 
 public class RenderEngine implements IForestryRenderer<TileEngine> {
+	// probably need one per engine?
+	public static final ModelLayerLocation ENGINE = IForestryRenderer.register("engine");
+	
+	private static final String EXTENSION = "EXTENSION";
+	private static final String PISTON = "PISTON";
+	private static final String TRUNK = "TRUNK";
+	private static final String BOILER = "BOILER";
+	
+	private final ModelPart boiler;
+	private final ModelPart trunk;
+	private final ModelPart piston;
+	private final ModelPart extension;
 
+	private ResourceLocation[] textures;
 	private enum Textures {
 
 		BASE, PISTON, EXTENSION, TRUNK_HIGHEST, TRUNK_HIGHER, TRUNK_HIGH, TRUNK_MEDIUM, TRUNK_LOW
@@ -46,7 +64,38 @@ public class RenderEngine implements IForestryRenderer<TileEngine> {
 		angleMap[Direction.NORTH.ordinal()] = (float) -Math.PI / 2;
 	}
 
-	public RenderEngine(String baseTexture) {
+	public RenderEngine(BlockEntityRendererProvider.Context ctx, String baseTexture) {
+		ModelPart root = ctx.bakeLayer(ENGINE);
+		boiler = root.getChild(BOILER);
+		trunk = root.getChild(TRUNK);
+		piston = root.getChild(PISTON);
+		extension = root.getChild(EXTENSION);
+		
+		textures = new ResourceLocation[]{
+				new ForestryResource(baseTexture + "base.png"),
+				new ForestryResource(baseTexture + "piston.png"),
+				new ForestryResource(baseTexture + "extension.png"),
+				new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/engine_trunk_highest.png"),
+				new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/engine_trunk_higher.png"),
+				new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/engine_trunk_high.png"),
+				new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/engine_trunk_medium.png"),
+				new ForestryResource(Constants.TEXTURE_PATH_BLOCK + "/engine_trunk_low.png"),};
+	}
+
+	public static LayerDefinition createBodyLayer() {
+		MeshDefinition meshdefinition = new MeshDefinition();
+        PartDefinition partdefinition = meshdefinition.getRoot();
+        
+        partdefinition.addOrReplaceChild(BOILER, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-8F, -8F, -8F, 16, 6, 16), PartPose.offset(8, 8, 8));
+        partdefinition.addOrReplaceChild(TRUNK, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-4F, -4F, -4F, 8, 12, 8), PartPose.offset(8, 8, 8));
+        partdefinition.addOrReplaceChild(PISTON, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-6F, -2, -6F, 12, 4, 12), PartPose.offset(8, 8, 8));
+        partdefinition.addOrReplaceChild(EXTENSION, CubeListBuilder.create().texOffs(0, 0)
+            	.addBox(-5F, -3, -5F, 10, 2, 10), PartPose.offset(8, 8, 8));
+
+		return LayerDefinition.create(meshdefinition, 64, 32);
 	}
 
 	@Override
@@ -82,20 +131,34 @@ public class RenderEngine implements IForestryRenderer<TileEngine> {
 
 		switch (orientation) {
 			case EAST, WEST, DOWN -> rotation.setZ(angleMap[orientation.ordinal()]);
-			case SOUTH, NORTH -> rotation.setX(angleMap[orientation.ordinal()]);
+			case SOUTH, NORTH, UP -> rotation.setX(angleMap[orientation.ordinal()]);
 		}
 
 		helper.setRotation(rotation);
+		helper.renderModel(textures[Textures.BASE.ordinal()], boiler);
 
 		helper.push();
 
 		helper.translate(translate[0] * tfactor, translate[1] * tfactor, translate[2] * tfactor);
+		helper.renderModel(textures[Textures.PISTON.ordinal()], piston);
 		helper.translate(-translate[0] * tfactor, -translate[1] * tfactor, -translate[2] * tfactor);
 
+		ResourceLocation texture = switch (state) {
+			case OVERHEATING -> textures[Textures.TRUNK_HIGHEST.ordinal()];
+			case RUNNING_HOT -> textures[Textures.TRUNK_HIGHER.ordinal()];
+			case OPERATING_TEMPERATURE -> textures[Textures.TRUNK_HIGH.ordinal()];
+			case WARMED_UP -> textures[Textures.TRUNK_MEDIUM.ordinal()];
+			case COOL -> textures[Textures.TRUNK_LOW.ordinal()];
+			default -> textures[Textures.TRUNK_LOW.ordinal()];
+		};
+		
+		helper.renderModel(texture, trunk);
+		
 		float chamberf = 2F / 16F;
 
 		if (step > 0) {
 			for (int i = 0; i <= step + 2; i += 2) {
+				helper.renderModel(textures[Textures.EXTENSION.ordinal()], extension);
 				helper.translate(translate[0] * chamberf, translate[1] * chamberf, translate[2] * chamberf);
 			}
 		}

--- a/src/main/java/forestry/energy/render/RenderEngine.java
+++ b/src/main/java/forestry/energy/render/RenderEngine.java
@@ -34,7 +34,6 @@ import forestry.core.tiles.TemperatureState;
 import forestry.energy.tiles.TileEngine;
 
 public class RenderEngine implements IForestryRenderer<TileEngine> {
-	// probably need one per engine?
 	public static final ModelLayerLocation ENGINE = IForestryRenderer.register("engine");
 	
 	private static final String EXTENSION = "EXTENSION";

--- a/src/main/java/genetics/api/root/EmptyRootDefinition.java
+++ b/src/main/java/genetics/api/root/EmptyRootDefinition.java
@@ -5,13 +5,15 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import genetics.api.individual.IIndividual;
+
 /**
  * A empty instance of an {@link IRootDefinition}.
  */
-public final class EmptyRootDefinition implements IRootDefinition {
-	private static final EmptyRootDefinition INSTANCE = new EmptyRootDefinition();
-
-	public static <R extends IIndividualRoot> IRootDefinition<R> empty() {
+public final class EmptyRootDefinition<T extends IIndividualRoot<?>> implements IRootDefinition<T> {
+	private static final EmptyRootDefinition<IIndividualRoot<?>> INSTANCE = new EmptyRootDefinition<>();
+	// ? extends IIndividualRoot<IIndividual>
+	public static <R extends IIndividualRoot<?>> IRootDefinition<R> empty() {
 		@SuppressWarnings("unchecked")
 		IRootDefinition<R> t = (IRootDefinition<R>) INSTANCE;
 		return t;
@@ -21,18 +23,18 @@ public final class EmptyRootDefinition implements IRootDefinition {
 	}
 
 	@Override
-	public Optional<IIndividualRoot> maybe() {
+	public Optional<T> maybe() {
 		return Optional.empty();
 	}
 
 	@Override
-	public IIndividualRoot get() {
+	public T get() {
 		throw new NullPointerException();
 	}
 
 	@Override
-	public IIndividualRoot cast() {
-		return get();
+	public <U extends IIndividualRoot> U cast() {
+		return (U)get();
 	}
 
 	@Override
@@ -41,7 +43,7 @@ public final class EmptyRootDefinition implements IRootDefinition {
 	}
 
 	@Override
-	public IIndividualRoot orElse(IIndividualRoot other) {
+	public T orElse(T other) {
 		return other;
 	}
 

--- a/src/main/java/genetics/api/root/EmptyRootDefinition.java
+++ b/src/main/java/genetics/api/root/EmptyRootDefinition.java
@@ -12,7 +12,6 @@ import genetics.api.individual.IIndividual;
  */
 public final class EmptyRootDefinition<T extends IIndividualRoot<?>> implements IRootDefinition<T> {
 	private static final EmptyRootDefinition<IIndividualRoot<?>> INSTANCE = new EmptyRootDefinition<>();
-	// ? extends IIndividualRoot<IIndividual>
 	public static <R extends IIndividualRoot<?>> IRootDefinition<R> empty() {
 		@SuppressWarnings("unchecked")
 		IRootDefinition<R> t = (IRootDefinition<R>) INSTANCE;

--- a/src/main/java/genetics/api/root/IIndividualRootHelper.java
+++ b/src/main/java/genetics/api/root/IIndividualRootHelper.java
@@ -31,7 +31,7 @@ public interface IIndividualRootHelper {
 	/**
 	 * Retrieve a matching {@link IRootDefinition} for the given {@link IIndividual}
 	 */
-	<R extends IIndividualRoot> IRootDefinition<R> getSpeciesRoot(IIndividual individual);
+	<R extends IIndividualRoot<?>> IRootDefinition<R> getSpeciesRoot(IIndividual individual);
 
 	<R extends IIndividualRoot> IRootDefinition<R> getSpeciesRoot(IIndividual individual, Class<? extends R> rootClass);
 

--- a/src/main/java/genetics/api/root/IRootDefinition.java
+++ b/src/main/java/genetics/api/root/IRootDefinition.java
@@ -7,7 +7,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import genetics.api.IGeneticApiInstance;
-import genetics.api.individual.IIndividual;
 
 /**
  * A optional that describes a {@link IIndividualRoot}.

--- a/src/main/java/genetics/api/root/IRootDefinition.java
+++ b/src/main/java/genetics/api/root/IRootDefinition.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import genetics.api.IGeneticApiInstance;
+import genetics.api.individual.IIndividual;
 
 /**
  * A optional that describes a {@link IIndividualRoot}.

--- a/src/main/java/genetics/root/IndividualRootHelper.java
+++ b/src/main/java/genetics/root/IndividualRootHelper.java
@@ -69,7 +69,7 @@ public enum IndividualRootHelper implements IIndividualRootHelper {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <R extends IIndividualRoot> IRootDefinition<R> getSpeciesRoot(IIndividual individual) {
+	public <R extends IIndividualRoot<?>> IRootDefinition<R> getSpeciesRoot(IIndividual individual) {
 		return (IRootDefinition<R>) individual.getRoot().getDefinition();
 	}
 


### PR DESCRIPTION
This updates the tite-entity renderers to "ModelPart/LayerDefinition" system, and re-adds RenderForestryItem for the same blocks' items.

Fluid tanks and floating bee items working OK.
Items render in inventory and creative menu.
Engines do show heat level, but the piston doesn't move. The movement is in the renderer, so maybe the block state doesn't sync.
Chest lid movement is in the renderer, but doesn't happen - similar block state sync.

![2022-06-12_16 40 56](https://user-images.githubusercontent.com/6420993/173242230-7f23e650-97e7-4a48-a48f-9c958a1a9029.png)

[BlockEntityWithoutLevelRenderer](https://mcforge.readthedocs.io/en/1.18.x/items/bewlr/) is the replacement for ItemStackTileEntityRenderer

IForestryRenderer - Interface unchanged, each class now needs ModelPart in constructor
IForestryRendererProvider - Lambda for above "ModelPart -> IForestryRenderer"
RenderForestryItem - BlockEntityWithoutLevelRenderer as before
ItemBlockBase - has initializeClient to register BlockEntityWithoutLevelRenderer (replaces 'setRenderer' proxy)
RenderForestryItemProperties - used by initializeClient, makes RenderForestryItem from info in ItemBlockBase (note weirdness with Forge calling "override method in super constructor")

- Tin/Apatite ores are still purple-square blocks.
- This is on top of other PR #2650 (so it works on later Forge versions)
- I updated to Gradle 7.4.2
- There are additional changes to "object to Boolean"/"IIndividualRoot" to fix Eclipse compile errors, even though the Gradle build allowed this.
- I haven't tested client/server separation.



