### PR TITLE
[1.16.5+] Fix Crop Farm spawning Dirt instead of Farmland

### DIFF
--- a/src/main/java/forestry/farming/FarmDefinition.java
+++ b/src/main/java/forestry/farming/FarmDefinition.java
@@ -48,7 +48,7 @@ public enum FarmDefinition implements IStringSerializable {
 	CROPS("crops", EnumElectronTube.BRONZE, FarmLogicCrops::new) {
 		@Override
 		protected void initProperties(IFarmPropertiesBuilder properties) {
-			wateredProperties(properties).addSoil(Blocks.DIRT)
+			wateredProperties(properties).addSoil(new ItemStack(Blocks.DIRT), Blocks.FARMLAND.defaultBlockState())
 				.addFarmables("Wheat")
 				.setIcon(() -> new ItemStack(Items.WHEAT));
 		}


### PR DESCRIPTION
The Crop Farm was spawning the same soil Block as the soil ItemStack (Dirt). Now it will spawn Farmland.