### PR TITLE
Buff to the bee tick rate and production method for bees' products

### DIFF
--- a/src/main/java/forestry/api/apiculture/IBeeModifier.java
+++ b/src/main/java/forestry/api/apiculture/IBeeModifier.java
@@ -8,6 +8,13 @@ package forestry.api.apiculture;
 import javax.annotation.Nullable;
 
 public interface IBeeModifier {
+
+	enum ProductionType {
+		FRAME,
+		OTHER
+	}
+
+	ProductionType TypeDefault = ProductionType.FRAME;
 	/**
 	 * @param genome          Genome of the bee this modifier is called for.
 	 * @param currentModifier Current modifier.

--- a/src/main/java/forestry/apiculture/BeeHousingModifier.java
+++ b/src/main/java/forestry/apiculture/BeeHousingModifier.java
@@ -15,9 +15,11 @@ import javax.annotation.Nullable;
 import forestry.api.apiculture.IBeeGenome;
 import forestry.api.apiculture.IBeeHousing;
 import forestry.api.apiculture.IBeeModifier;
+import scala.Product;
 
 public class BeeHousingModifier implements IBeeModifier {
 	private final IBeeHousing beeHousing;
+	private final ProductionType type = TypeDefault;
 
 	public BeeHousingModifier(IBeeHousing beeHousing) {
 		this.beeHousing = beeHousing;
@@ -56,10 +58,12 @@ public class BeeHousingModifier implements IBeeModifier {
 		int count = 0;
 
 		for (IBeeModifier modifier : beeHousing.getBeeModifiers()) {
-			count++;
 			modifierValue *= modifier.getProductionModifier(genome, modifierValue * currentModifier);
-			if (count == 4) {
-				break;
+			if (this.type == TypeDefault) {
+				count++;
+				if (count == 4) {
+					break;
+				}
 			}
 		}
 		return modifierValue;

--- a/src/main/java/forestry/apiculture/BeeHousingModifier.java
+++ b/src/main/java/forestry/apiculture/BeeHousingModifier.java
@@ -58,7 +58,7 @@ public class BeeHousingModifier implements IBeeModifier {
 		for (IBeeModifier modifier : beeHousing.getBeeModifiers()) {
 			count++;
 			modifierValue *= modifier.getProductionModifier(genome, modifierValue * currentModifier);
-			if (count = 4) {
+			if (count == 4) {
 				break;
 			}
 		}

--- a/src/main/java/forestry/apiculture/BeeHousingModifier.java
+++ b/src/main/java/forestry/apiculture/BeeHousingModifier.java
@@ -53,8 +53,14 @@ public class BeeHousingModifier implements IBeeModifier {
 	@Override
 	public float getProductionModifier(IBeeGenome genome, final float currentModifier) {
 		float modifierValue = 1.0f;
+		int count = 0;
+
 		for (IBeeModifier modifier : beeHousing.getBeeModifiers()) {
+			count++;
 			modifierValue *= modifier.getProductionModifier(genome, modifierValue * currentModifier);
+			if (count = 4) {
+				break;
+			}
 		}
 		return modifierValue;
 	}

--- a/src/main/java/forestry/apiculture/ModuleApiculture.java
+++ b/src/main/java/forestry/apiculture/ModuleApiculture.java
@@ -155,7 +155,8 @@ public class ModuleApiculture extends BlankForestryModule {
 
 	public static String beekeepingMode = "NORMAL";
 
-	public static int ticksPerBeeWorkCycle = 550;
+	// Previous value was 550 (~27 IRL seconds) - way too high. It's better IMO to scale down the production (or up) rather than have a very long tick rate and an enormous output at once
+	public static int ticksPerBeeWorkCycle = 40;
 
 	public static boolean hivesDamageOnPeaceful = false;
 
@@ -287,7 +288,8 @@ public class ModuleApiculture extends BlankForestryModule {
 		String[] blacklist = config.getStringListLocalized("species", "blacklist", Constants.EMPTY_STRINGS);
 		parseBeeBlacklist(blacklist);
 
-		ticksPerBeeWorkCycle = config.getIntLocalized("beekeeping", "ticks.work", 550, 250, 850);
+		// Honestly I'm not sure the min/max values from this function do anything
+		ticksPerBeeWorkCycle = config.getIntLocalized("beekeeping", "ticks.work", ticksPerBeeWorkCycle, ticksPerBeeWorkCycle, ticksPerBeeWorkCycle);
 
 		hivesDamageOnPeaceful = config.getBooleanLocalized("beekeeping.hivedamage", "peaceful", hivesDamageOnPeaceful);
 

--- a/src/main/java/forestry/apiculture/ModuleApiculture.java
+++ b/src/main/java/forestry/apiculture/ModuleApiculture.java
@@ -156,7 +156,8 @@ public class ModuleApiculture extends BlankForestryModule {
 	public static String beekeepingMode = "NORMAL";
 
 	// Previous value was 550 (~27 IRL seconds) - way too high. It's better IMO to scale down the production (or up) rather than have a very long tick rate and an enormous output at once
-	public static int ticksPerBeeWorkCycle = 40;
+	// Is set later from the config file, by default is set to 40 ticks
+	public static int ticksPerBeeWorkCycle;
 
 	public static boolean hivesDamageOnPeaceful = false;
 
@@ -288,8 +289,7 @@ public class ModuleApiculture extends BlankForestryModule {
 		String[] blacklist = config.getStringListLocalized("species", "blacklist", Constants.EMPTY_STRINGS);
 		parseBeeBlacklist(blacklist);
 
-		// Honestly I'm not sure the min/max values from this function do anything
-		ticksPerBeeWorkCycle = config.getIntLocalized("beekeeping", "ticks.work", ticksPerBeeWorkCycle, ticksPerBeeWorkCycle, ticksPerBeeWorkCycle);
+		ticksPerBeeWorkCycle = config.getIntLocalized("beekeeping", "ticks.work", 40, 20, 550);
 
 		hivesDamageOnPeaceful = config.getBooleanLocalized("beekeeping.hivedamage", "peaceful", hivesDamageOnPeaceful);
 
@@ -304,6 +304,7 @@ public class ModuleApiculture extends BlankForestryModule {
 		doSelfPollination = config.getBooleanLocalized("beekeeping", "self.pollination", false);
 
 		config.save();
+
 
 		// Genetics
 		createAlleles();

--- a/src/main/java/forestry/apiculture/genetics/Bee.java
+++ b/src/main/java/forestry/apiculture/genetics/Bee.java
@@ -477,26 +477,54 @@ public class Bee extends IndividualLiving implements IBee {
 		IBeeModifier beeHousingModifier = BeeManager.beeRoot.createBeeHousingModifier(housing);
 		IBeeModifier beeModeModifier = mode.getBeeModifier();
 
-		// Bee genetic speed * beehousing * beekeeping mode
-		float speed = genome.getSpeed() * beeHousingModifier.getProductionModifier(genome, 1f) * beeModeModifier.getProductionModifier(genome, 1f);
+		// Old formula is this: Bee genetic speed * beehousing * beekeeping mode
+		// Goal is to have one that follows a better progression if we consider a maximum of 4 frames (TODO: implement frames cap)
+		float prodHousing = beeHousingModifier.getProductionModifier(genome, 1.0f);
+		float speedBee = genome.getSpeed();
 
+		// Taking inspiration from GTNH, though we skip the ProductChance ^ 0.52
+		float chance = (float)Math.pow(prodHousing, 0.52f) * (float)Math.pow(speedBee, 0.37f);
+		float lineChance = 0.0f;
+
+		// The idea of the 2 blocks below are to allow more than 1 output for the same Product. If you have a total chance of 350%, this should be 3 guaranteed of this product + 50% chance of a 4th one
 		// / Primary Products
 		for (Map.Entry<ItemStack, Float> entry : primary.getProductChances().entrySet()) {
-			if (world.rand.nextFloat() < entry.getValue() * speed) {
+			float productChance = entry.getValue();
+			lineChance = chance * productChance;
+			while (lineChance > 1.0f) {
+				products.add(entry.getKey().copy());
+				lineChance--;
+			}
+			if (world.rand.nextFloat() < lineChance) {
 				products.add(entry.getKey().copy());
 			}
 		}
-		// / Secondary Products
-		for (Map.Entry<ItemStack, Float> entry : secondary.getProductChances().entrySet()) {
-			if (world.rand.nextFloat() < Math.round(entry.getValue() / 2) * speed) {
-				products.add(entry.getKey().copy());
-			}
-		}
+
+		// This entire block is rendered useless as Primary is considered the whole 1st line in JEI. We can skip this as this would double the yield. Keeping it as I might reuse it later
+		
+		// // / Secondary Products
+		// for (Map.Entry<ItemStack, Float> entry : secondary.getProductChances().entrySet()) {
+		// 	float productChance = entry.getValue();
+		// 	lineChance = chance * productChance;
+		// 	while (lineChance > 1.0f) {
+		// 		products.add(entry.getKey().copy());
+		// 		lineChance--;
+		// 	}
+		// 	if (world.rand.nextFloat() < lineChance) {
+		// 		products.add(entry.getKey().copy());
+		// 	}
+		// }
 
 		// / Specialty products
 		if (primary.isJubilant(genome, housing) && secondary.isJubilant(genome, housing)) {
 			for (Map.Entry<ItemStack, Float> entry : primary.getSpecialtyChances().entrySet()) {
-				if (world.rand.nextFloat() < entry.getValue() * speed) {
+				float productChance = entry.getValue();
+				lineChance = chance * productChance;
+				while (lineChance > 1.0f) {
+					products.add(entry.getKey().copy());
+					lineChance--;
+				}
+				if (world.rand.nextFloat() < lineChance) {
 					products.add(entry.getKey().copy());
 				}
 			}

--- a/src/main/java/forestry/apiculture/genetics/Bee.java
+++ b/src/main/java/forestry/apiculture/genetics/Bee.java
@@ -470,6 +470,8 @@ public class Bee extends IndividualLiving implements IBee {
 		IBeekeepingMode mode = BeeManager.beeRoot.getBeekeepingMode(world);
 
 		NonNullList<ItemStack> products = NonNullList.create();
+		ItemStack singleProduct;
+		int productCount;
 
 		IAlleleBeeSpecies primary = genome.getPrimary();
 		IAlleleBeeSpecies secondary = genome.getSecondary();
@@ -484,20 +486,20 @@ public class Bee extends IndividualLiving implements IBee {
 		// Taking inspiration from GTNH, though we skip the ProductChance ^ 0.52 from their formula
 		// https://gtnh.miraheze.org/wiki/Bees
 		float chance = (float)Math.pow(prodHousing, 0.52f) * (float)Math.pow(speedBee, 0.37f);
-		float lineChance = 0.0f;
+		float lineChance;
 
 		// The idea of the 2 blocks below are to allow more than 1 output for the same Product. If you have a total chance of 350%, this should be 3 guaranteed of this product + 50% chance of a 4th one
 		// / Primary Products
 		for (Map.Entry<ItemStack, Float> entry : primary.getProductChances().entrySet()) {
 			float productChance = entry.getValue();
 			lineChance = chance * productChance;
-			while (lineChance > 1.0f) {
-				products.add(entry.getKey().copy());
-				lineChance--;
+			productCount = (int) lineChance;
+			if (world.rand.nextFloat() < (lineChance - (float) productCount)) {
+				productCount++;
 			}
-			if (world.rand.nextFloat() < lineChance) {
-				products.add(entry.getKey().copy());
-			}
+			singleProduct = entry.getKey().copy();
+			singleProduct.setCount(productCount);
+			products.add(singleProduct);
 		}
 
 		/*
@@ -513,13 +515,13 @@ public class Bee extends IndividualLiving implements IBee {
 			for (Map.Entry<ItemStack, Float> entry : primary.getSpecialtyChances().entrySet()) {
 				float productChance = entry.getValue();
 				lineChance = chance * productChance;
-				while (lineChance > 1.0f) {
-					products.add(entry.getKey().copy());
-					lineChance--;
+				productCount = (int) lineChance;
+				if (world.rand.nextFloat() < (lineChance - (float) productCount)) {
+					productCount++;
 				}
-				if (world.rand.nextFloat() < lineChance) {
-					products.add(entry.getKey().copy());
-				}
+				singleProduct = entry.getKey().copy();
+				singleProduct.setCount(productCount);
+				products.add(singleProduct);
 			}
 		}
 

--- a/src/main/java/forestry/apiculture/genetics/Bee.java
+++ b/src/main/java/forestry/apiculture/genetics/Bee.java
@@ -475,14 +475,14 @@ public class Bee extends IndividualLiving implements IBee {
 		IAlleleBeeSpecies secondary = genome.getSecondary();
 
 		IBeeModifier beeHousingModifier = BeeManager.beeRoot.createBeeHousingModifier(housing);
-		IBeeModifier beeModeModifier = mode.getBeeModifier();
 
 		// Old formula is this: Bee genetic speed * beehousing * beekeeping mode
-		// Goal is to have one that follows a better progression if we consider a maximum of 4 frames (TODO: implement frames cap)
+		// Goal is to have one that follows a better progression if we consider a maximum of 4 frames
 		float prodHousing = beeHousingModifier.getProductionModifier(genome, 1.0f);
 		float speedBee = genome.getSpeed();
 
-		// Taking inspiration from GTNH, though we skip the ProductChance ^ 0.52
+		// Taking inspiration from GTNH, though we skip the ProductChance ^ 0.52 from their formula
+		// https://gtnh.miraheze.org/wiki/Bees
 		float chance = (float)Math.pow(prodHousing, 0.52f) * (float)Math.pow(speedBee, 0.37f);
 		float lineChance = 0.0f;
 
@@ -500,20 +500,13 @@ public class Bee extends IndividualLiving implements IBee {
 			}
 		}
 
-		// This entire block is rendered useless as Primary is considered the whole 1st line in JEI. We can skip this as this would double the yield. Keeping it as I might reuse it later
-		
-		// // / Secondary Products
-		// for (Map.Entry<ItemStack, Float> entry : secondary.getProductChances().entrySet()) {
-		// 	float productChance = entry.getValue();
-		// 	lineChance = chance * productChance;
-		// 	while (lineChance > 1.0f) {
-		// 		products.add(entry.getKey().copy());
-		// 		lineChance--;
-		// 	}
-		// 	if (world.rand.nextFloat() < lineChance) {
-		// 		products.add(entry.getKey().copy());
-		// 	}
-		// }
+		/*
+		Correction from last commit: This block is for the second genome's produce. However in practice, the first row can drop from the "Primary Products"
+		Also, relying on a non pure-breed bee is more of a pain (for the player) than anything, so this can be safely ignored in my opinion
+
+		 // Secondary Products
+		 for (Map.Entry<ItemStack, Float> entry : secondary.getProductChances().entrySet()) {}
+		 */
 
 		// / Specialty products
 		if (primary.isJubilant(genome, housing) && secondary.isJubilant(genome, housing)) {


### PR DESCRIPTION
The problems and possible solutions I tried to implement:
- Bee tick rate was set to 550t/bee cycle (27.5s). This is way too high to properly scale this, adding to that the 1 per cycle *at maximum* for the specialty output (and 2 for primary output)
    - Solution: set the default to 40. This *should* be possible to change it in the config file, I removed the hardcoded value just to be safe, I honestly have no idea if this was the issue.
- Products output was capped, 1 per primary, 1 per secondary, 1 per specialty. This is especially bad since you already have a very long waiting time for ONE output, but even stacking more productivity and speed does nothing to it
    - Solution: changed the formula to have a productivity based drop instead of a chance based drop. Meaning that a chance of 350% chance/productivity will yield 3 products + 50% of a 4th.
    - The productivity formula is based off of GT:NH [(here)](https://gtnh.miraheze.org/wiki/Bees), but removed the tier based formula
    - I did end up removing the Secondary output, but not using pure-breed feels more punishing and random, which just seems against scaling up

Essentially, the idea of this as a whole is to scale up the production rather than the time factor. For Gregtech players especially, this makes it a competitive option for ore generation, and/or a nice complement. 

I did add a cap on how many frames an alveary can have, at 4, as the lower tick rate already makes it worth just running 1 alveary and adding more if necessary. For mods integrating with Forestry such as Greg, better frames also scale higher, which is a fine compromise I think

Here are some numbers:

Frame(s) | Product Chance (%) | Housing Productivity | Bee Speed | Output (cycle)
-- | -- | -- | -- | --
No Frame | 30% | 100% | 60% | 0,3686585536
1x 200% Frame | 30% | 200% | 60% | 0,4645113526
2x 200% Frame | 30% | 400% | 60% | 0,6215128608
3x 200% Frame | 30% | 800% | 60% | 0,8688712912
4x 200% Frame | 30% | 1600% | 60% | 1,248513097
4x 400% Frame (Gregtech) | 30% | 25600% | 60% | 5,870824496
4x 1000% Frame (Gregtech) | 30% | 1000000% | 60% | 47,32187793
