### PR TITLE
Prevent tick acceleration from consuming queen work cache

### DIFF
--- a/src/main/java/forestry/apiculture/BeekeepingLogic.java
+++ b/src/main/java/forestry/apiculture/BeekeepingLogic.java
@@ -528,21 +528,28 @@ public class BeekeepingLogic implements IBeekeepingLogic {
 
 		private Set<IErrorState> queenCanWorkCached = Collections.emptySet();
 		private int queenCanWorkCooldown = 0;
+		private long queenCanWorkLastWorldTick = Long.MIN_VALUE;
 
 		public Set<IErrorState> queenCanWork(IBee queen, IBeeHousing beeHousing) {
+			long worldTick = beeHousing.getWorldObj().getTotalWorldTime();
+			if (worldTick == queenCanWorkLastWorldTick) {
+				return queenCanWorkCached;
+			}
+
 			if (queenCanWorkCooldown <= 0) {
 				queenCanWorkCached = queen.getCanWork(beeHousing);
 				queenCanWorkCooldown = ticksPerCheckQueenCanWork;
 			} else {
 				queenCanWorkCooldown--;
 			}
-
+			queenCanWorkLastWorldTick = worldTick;
 			return queenCanWorkCached;
 		}
 
 		public void clear() {
 			queenCanWorkCached.clear();
 			queenCanWorkCooldown = 0;
+			queenCanWorkLastWorldTick = Long.MIN_VALUE;
 		}
 	}
 


### PR DESCRIPTION
Make the queen work cache advance at most once per world tick, unless explicitly invalidated.

This keeps ALLnormal Forestry behavior unchanged while preventing tick accelerators from consuming the cache cooldown too quickly. For example, a Temporal Bee can reduce the effective cache interval to about 1.2 real ticks, causing environmental checks to run almost every tick per accelerated apiary.

This is a small performance improvement for modern modpacks with many acceleration options, especially largescale apiary setups running permanently accelerated.
